### PR TITLE
a2md: abort() in the abort_fn

### DIFF
--- a/a2md/md_main.c
+++ b/a2md/md_main.c
@@ -277,7 +277,7 @@ void md_cmd_print_md(md_cmd_ctx *ctx, const md_t *md)
 
 static int pool_abort(int rv)
 {
-    exit(1);
+    abort();
 }
 
 apr_array_header_t *md_cmd_gather_args(md_cmd_ctx *ctx, int index)


### PR DESCRIPTION
Instead of just silently exiting if the APR pool system fails, abort loudly (this will dump core and signal debuggers, which helps track down problems). This would have been helpful for tracking down #4 :grin: