### PR TITLE
md_json_writep: return NULL if json_dump_callback() fails

### DIFF
--- a/a2md/md_main.c
+++ b/a2md/md_main.c
@@ -406,6 +406,8 @@ int main(int argc, const char *const *argv)
     rv = cmd_process(&ctx, &MainCmd);
     
     if (ctx.json_out) {
+        const char *out;
+
         md_json_setl(rv, ctx.json_out, "status", NULL);
         if (APR_SUCCESS != rv) {
             char errbuff[32];
@@ -413,7 +415,13 @@ int main(int argc, const char *const *argv)
             apr_strerror(rv, errbuff, sizeof(errbuff)/sizeof(errbuff[0]));
             md_json_sets(apr_pstrdup(p, errbuff), ctx.json_out, "description", NULL);
         }
-        fprintf(stdout, "%s\n", md_json_writep(ctx.json_out, p, MD_JSON_FMT_INDENT));
+
+        out = md_json_writep(ctx.json_out, p, MD_JSON_FMT_INDENT);
+        if (!out) {
+            rv = APR_EINVAL;
+        }
+
+        fprintf(stdout, "%s\n", out ? out : "<failed to serialize!>");
     }
     
     return (rv == APR_SUCCESS)? 0 : 1;

--- a/src/acme/md_acme_acct.c
+++ b/src/acme/md_acme_acct.c
@@ -391,14 +391,16 @@ static apr_status_t acct_valid(md_acme_t *acme, apr_pool_t *p, const apr_table_t
 {
     md_acme_acct_t *acct = acme->acct;
     apr_status_t rv = APR_SUCCESS;
+    const char *body_str;
     const char *tos_required;
     
     apr_array_clear(acct->contacts);
     md_json_getsa(acct->contacts, body, MD_KEY_CONTACT, NULL);
     acct->registration = md_json_clone(acme->p, body);
     
+    body_str = md_json_writep(body, acme->p, MD_JSON_FMT_INDENT);
     md_log_perror(MD_LOG_MARK, MD_LOG_DEBUG, rv, acme->p, "validate acct %s: %s", 
-                  acct->url, md_json_writep(body, acme->p, MD_JSON_FMT_INDENT));
+                  acct->url, body_str ? body_str : "<failed to serialize!>");
     
     acct->agreement = md_json_gets(acct->registration, MD_KEY_AGREEMENT, NULL);
     tos_required = md_link_find_relation(hdrs, acme->p, "terms-of-service");

--- a/src/md_json.c
+++ b/src/md_json.c
@@ -778,9 +778,17 @@ const char *md_json_writep(md_json_t *json, apr_pool_t *p, md_json_fmt_t fmt)
 {
     size_t flags = (fmt == MD_JSON_FMT_COMPACT)? JSON_COMPACT : JSON_INDENT(2); 
     apr_array_header_t *chunks;
+    int rv;
 
     chunks = apr_array_make(p, 10, sizeof(char *));
-    json_dump_callback(json->j, chunk_cb, chunks, flags);
+    rv = json_dump_callback(json->j, chunk_cb, chunks, flags);
+
+    if (rv) {
+        md_log_perror(MD_LOG_MARK, MD_LOG_ERR, 0, p,
+                      "md_json_writep failed to dump JSON");
+        return NULL;
+    }
+
     switch (chunks->nelts) {
         case 0:
             return "";
@@ -797,7 +805,14 @@ apr_status_t md_json_writef(md_json_t *json, apr_pool_t *p, md_json_fmt_t fmt, a
     const char *s;
     
     s = md_json_writep(json, p, fmt);
-    rv = apr_file_write_full(f, s, strlen(s), NULL);
+
+    if (s) {
+        rv = apr_file_write_full(f, s, strlen(s), NULL);
+    }
+    else {
+        rv = APR_EINVAL;
+    }
+
     if (APR_SUCCESS != rv) {
         md_log_perror(MD_LOG_MARK, MD_LOG_ERR, rv, json->p, "md_json_writef");
     }

--- a/src/md_jws.c
+++ b/src/md_jws.c
@@ -55,16 +55,24 @@ apr_status_t md_jws_sign(md_json_t **pmsg, apr_pool_t *p,
     }
     apr_table_do(header_set, jprotected, protected, NULL);
     prot = md_json_writep(jprotected, p, MD_JSON_FMT_COMPACT);
-    md_log_perror(MD_LOG_MARK, MD_LOG_TRACE4, 0, p, "protected: %s", prot); 
-    
-    prot64 = md_util_base64url_encode(prot, strlen(prot), p);
-    md_json_sets(prot64, msg, "protected", NULL);
-    pay64 = md_util_base64url_encode(payload, len, p);
-    
-    md_json_sets(pay64, msg, "payload", NULL);
-    sign = apr_psprintf(p, "%s.%s", prot64, pay64);
+    md_log_perror(MD_LOG_MARK, MD_LOG_TRACE4, 0, p, "protected: %s",
+                  prot ? prot : "<failed to serialize!>");
 
-    rv = md_crypt_sign64(&sign64, pkey, p, sign, strlen(sign));
+    if (!prot) {
+        rv = APR_EINVAL;
+    }
+    
+    if (rv == APR_SUCCESS) {
+        prot64 = md_util_base64url_encode(prot, strlen(prot), p);
+        md_json_sets(prot64, msg, "protected", NULL);
+        pay64 = md_util_base64url_encode(payload, len, p);
+
+        md_json_sets(pay64, msg, "payload", NULL);
+        sign = apr_psprintf(p, "%s.%s", prot64, pay64);
+
+        rv = md_crypt_sign64(&sign64, pkey, p, sign, strlen(sign));
+    }
+
     if (rv == APR_SUCCESS) {
         md_log_perror(MD_LOG_MARK, MD_LOG_TRACE3, 0, p, 
                       "jws pay64=%s\nprot64=%s\nsign64=%s", pay64, prot64, sign64);

--- a/src/md_jws.c
+++ b/src/md_jws.c
@@ -37,7 +37,7 @@ apr_status_t md_jws_sign(md_json_t **pmsg, apr_pool_t *p,
 {
     md_json_t *msg, *jprotected;
     const char *prot64, *pay64, *sign64, *sign, *prot;
-    apr_status_t rv;
+    apr_status_t rv = APR_SUCCESS;
 
     *pmsg = NULL;
     


### PR DESCRIPTION
Zeroing in on the JSON file truncation. If a `json_t*` is corrupted, `md_json_writep()` will currently just stop and report success with a partially serialized string. This patch returns `NULL` instead, and changes callers to handle a `NULL` return value correctly.