### PR TITLE
RFC: C-based unit test suite

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,10 @@ mod_cert-*.tar.gz
 m4
 .cache
 a2md/a2md
+
+# Automake test-suite artifacts
+/test-driver
+/test/test-suite.log
+/test/unit/**/*.log
+/test/unit/**/*.trs
+/test/unit/main

--- a/configure.ac
+++ b/configure.ac
@@ -50,6 +50,11 @@ AC_ARG_ENABLE([werror],
                     [Turn on compile time warnings])],
     [werror=$enableval], [werror=no])
 
+AC_ARG_ENABLE([unit-tests],
+    [AS_HELP_STRING([--enable-unit-tests],
+                    [Enable C-based unit tests (requires libcheck)])],
+    [enable_unit_tests=$enableval], [enable_unit_tests=yes])
+
 AC_ARG_WITH([apxs], [AS_HELP_STRING([--with-apxs],
     [Use APXS executable [default=check]])],
     [request_apxs=$withval], [request_apxs=check])
@@ -124,6 +129,10 @@ if test "x$werror" != "xno"; then
     AX_CHECK_COMPILE_FLAG(["-std=c89"], [CFLAGS="$CFLAGS -std=c89"])
     AX_CHECK_COMPILE_FLAG([-Wdeclaration-after-statement], [CFLAGS="$CFLAGS -Wdeclaration-after-statement"])
 fi
+
+# Do we have a pkg-config?
+AC_ARG_VAR([PKGCONFIG], [pkg-config executable])
+AC_PATH_PROG([PKGCONFIG], [pkg-config])
 
 # This is all experimental by default for now
 MD_EXPERIMENTAL=1
@@ -241,6 +250,30 @@ fi
 AM_CONDITIONAL([FOUND_OPENSSL_BIN], [test "x$FOUND_OPENSSL_BIN" != xno])
 AM_COND_IF([FOUND_OPENSSL_BIN],,[AC_MSG_ERROR([required program 'openssl' not found.])])
 AC_SUBST(OPENSSL_BIN)
+
+# Should we build unit tests?
+have_check=false
+
+if test "x$enable_unit_tests" != "xno"; then
+    # The Check library is needed for C-based unit tests. Only pkg-config
+    # discovery is supported for it at the moment.
+    AC_MSG_CHECKING([for Check to enable unit tests])
+
+    if test "x$PKGCONFIG" != "x" && $PKGCONFIG --atleast-version='0.9.12' check; then
+        CHECK_CFLAGS=`$PKGCONFIG --cflags check`
+        CHECK_LIBS=`$PKGCONFIG --libs check`
+
+        AC_SUBST(CHECK_CFLAGS)
+        AC_SUBST(CHECK_LIBS)
+
+        have_check=true
+        AC_MSG_RESULT([yes])
+    else
+        AC_MSG_RESULT([no])
+    fi
+fi
+
+AM_CONDITIONAL([BUILD_UNIT_TESTS], [test "x$have_check" = "xtrue"])
 
 # Checks for header files.
 AC_CHECK_HEADERS([ \

--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -21,8 +21,11 @@ TESTS = unit/main
 
 check_PROGRAMS = unit/main
 
-unit_main_CFLAGS = $(CHECK_CFLAGS)
-unit_main_LDADD  = $(CHECK_LIBS) -l$(LIB_APR) -l$(LIB_APRUTIL)
+unit_main_SOURCES = unit/main.c unit/md_json.c
+unit_main_LDADD   = $(top_builddir)/src/libapachemd.la
+
+unit_main_CFLAGS  = $(CHECK_CFLAGS) -I$(top_srcdir)/src
+unit_main_LDADD  += $(CHECK_LIBS) -l$(LIB_APR) -l$(LIB_APRUTIL)
 endif
 
 all: $(SERVER_DIR)/.test-setup

--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -16,6 +16,15 @@
 SERVER_DIR     = @SERVER_DIR@
 GEN            = gen
 
+if BUILD_UNIT_TESTS
+TESTS = unit/main
+
+check_PROGRAMS = unit/main
+
+unit_main_CFLAGS = $(CHECK_CFLAGS)
+unit_main_LDADD  = $(CHECK_LIBS) -l$(LIB_APR) -l$(LIB_APRUTIL)
+endif
+
 all: $(SERVER_DIR)/.test-setup
 
 $(SERVER_DIR)/conf/ssl/valid_pkey.pem:

--- a/test/unit/main.c
+++ b/test/unit/main.c
@@ -1,0 +1,48 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <apr.h>   /* for pid_t on Windows, needed by Check */
+#include <check.h>
+
+#include <apr_general.h>
+
+static Suite *main_test_suite(void)
+{
+    Suite *suite = suite_create("main");
+
+    return suite;
+}
+
+int main(int argc, const char * const argv[])
+{
+    SRunner *runner;
+    int failed;
+
+    /* Initialize APR and create our test runner. */
+    apr_app_initialize(&argc, &argv, NULL);
+    runner = srunner_create(main_test_suite());
+
+    /* Log TAP to stdout. */
+    srunner_set_tap(runner, "-");
+
+    /* Run the tests and collect failures. */
+    srunner_run_all(runner, CK_SILENT /* output only TAP */);
+    failed = srunner_ntests_failed(runner);
+
+    /* Clean up. */
+    srunner_free(runner);
+    apr_terminate();
+
+    return failed ? 1 : 0;
+}

--- a/test/unit/main.c
+++ b/test/unit/main.c
@@ -12,14 +12,15 @@
  * limitations under the License.
  */
 
-#include <apr.h>   /* for pid_t on Windows, needed by Check */
-#include <check.h>
+#include "test_common.h"
 
 #include <apr_general.h>
 
 static Suite *main_test_suite(void)
 {
     Suite *suite = suite_create("main");
+
+    suite_add_tcase(suite, md_json_test_case());
 
     return suite;
 }

--- a/test/unit/md_json.c
+++ b/test/unit/md_json.c
@@ -1,0 +1,59 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <stdlib.h>
+
+#include "test_common.h"
+
+#include "md_json.h"
+
+/*
+ * Test Fixture -- runs once per test
+ */
+
+static apr_pool_t *g_pool;
+
+static void md_json_setup(void)
+{
+    if (apr_pool_create(&g_pool, NULL) != APR_SUCCESS) {
+        exit(1);
+    }
+}
+
+static void md_json_teardown(void)
+{
+    apr_pool_destroy(g_pool);
+}
+
+/*
+ * Tests
+ */
+
+START_TEST(first_test)
+{
+    md_json_t *j = md_json_create(g_pool);
+    ck_assert(j);
+}
+END_TEST
+
+TCase *md_json_test_case(void)
+{
+    TCase *testcase = tcase_create("md_json");
+
+    tcase_add_checked_fixture(testcase, md_json_setup, md_json_teardown);
+
+    tcase_add_test(testcase, first_test);
+
+    return testcase;
+}

--- a/test/unit/test_common.h
+++ b/test/unit/test_common.h
@@ -1,0 +1,28 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * Common headers and declarations needed by most/all test source files.
+ */
+
+#include <apr.h>   /* for pid_t on Windows, needed by Check */
+#include <check.h>
+
+/*
+ * A list of Check test case declarations, usually one per source file. Add your
+ * test case here when adding a new source file, then add it to the
+ * main_test_suite() in main.c.
+ */
+
+TCase *md_json_test_case(void);


### PR DESCRIPTION
Only three tests for now, but I wanted to get it up on Github before the weekend hit.

As long as you have [Check](https://libcheck.github.io/check/) installed (Debian/Ubuntu have standard packages for it), it should Just Work:

- configure uses pkg-config for discovery.
- the test suite itself is hooked into Automake for eventual TAP parsing, so you run `make check` to get it to build and execute.
- the configure option `--disable-unit-tests` can force it not to build, if for some reason you want that.

Note that Check is LGPL, which may affect distribution of the fully-linked test binaries, if for some reason that is an issue. Let me know what you think!