### PR TITLE
Makefile: remove duplicate PHONY targets

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -20,18 +20,7 @@ ACLOCAL_AMFLAGS = -I m4
 
 dist_doc_DATA   = README README.md LICENSE
 
-.PHONY: all test a2md mod_md libmd
-
-all: a2md mod_md
-
-src/libapachemd.la: src/*.*
-	$(MAKE) -C src
-
-a2md: src/libapachemd.la
-	$(MAKE) -C a2md
-
-mod_md: src/libapachemd.la
-	$(MAKE) -C mod_md
+.PHONY: test
 
 test: a2md/a2md mod_md/mod_md.la
 	$(MAKE) -C test/ test


### PR DESCRIPTION
Since src, a2md, and mod_md are already declared as SUBDIRS, don't
duplicate their work in the main Makefile; it breaks parallel builds.
Fixes #10.