### PR TITLE
Fix the 'objects' serialization unit test by preserving object order

### DIFF
--- a/src/md_json.c
+++ b/src/md_json.c
@@ -753,7 +753,11 @@ typedef struct {
 /* Convert from md_json_fmt_t to the Jansson json_dumpX flags. */
 static size_t fmt_to_flags(md_json_fmt_t fmt)
 {
-    return (fmt == MD_JSON_FMT_COMPACT) ? JSON_COMPACT : JSON_INDENT(2); 
+    /* NOTE: JSON_PRESERVE_ORDER is off by default before Jansson 2.8. It
+     * doesn't have any semantic effect on the protocol, but it does let the
+     * md_json_writeX unit tests run deterministically. */
+    return JSON_PRESERVE_ORDER |
+           ((fmt == MD_JSON_FMT_COMPACT) ? JSON_COMPACT : JSON_INDENT(2)); 
 }
 
 static int dump_cb(const char *buffer, size_t len, void *baton)


### PR DESCRIPTION
The [string comparisons](https://github.com/icing/mod_md/blob/master/test/unit/test_md_json.c#L287-L299) in the md_json unit tests fail sporadically when using Jansson 2.7 and before, because the serialization order for objects' key-value pairs isn't defined unless `JSON_PRESERVE_ORDER` is set.

(Jansson 2.8 and later effectively force that flag on.)