### PR TITLE
Send "Content-Length" only, without "Transfer-Encoding: chunked"

### DIFF
--- a/src/md_curl.c
+++ b/src/md_curl.c
@@ -294,6 +294,12 @@ static apr_status_t internals_setup(md_http_request_t *req)
         curl_easy_setopt(curl, CURLOPT_LOW_SPEED_TIME, timeout_sec(req->timeout.stalled));
     }
     
+    if (req->body_len >= 0) {
+        /* set the Content-Length */
+        curl_easy_setopt(curl, CURLOPT_INFILESIZE_LARGE, (curl_off_t)req->body_len);
+        curl_easy_setopt(curl, CURLOPT_POSTFIELDSIZE_LARGE, (curl_off_t)req->body_len);
+    }
+    
     if (req->user_agent) {
         curl_easy_setopt(curl, CURLOPT_USERAGENT, req->user_agent);
     }

--- a/src/md_http.c
+++ b/src/md_http.c
@@ -207,19 +207,8 @@ void md_http_set_on_response_cb(md_http_request_t *req, md_http_response_cb *cb,
     req->cb.on_response_data = baton;
 }
 
-static void req_init_cl(md_http_request_t *req)
-{
-    if (req->body_len == 0 && apr_strnatcasecmp("GET", req->method)) {
-        apr_table_setn(req->headers, "Content-Length", "0");
-    }
-    else if (req->body_len > 0) {
-        apr_table_setn(req->headers, "Content-Length", apr_off_t_toa(req->pool, req->body_len));
-    }
-}
-
 apr_status_t md_http_perform(md_http_request_t *req)
 {
-    req_init_cl(req);
     return req->http->impl->perform(req);
 }
 
@@ -232,11 +221,8 @@ static apr_status_t proxy_nextreq(md_http_request_t **preq, void *baton,
                                       md_http_t *http, int in_flight)
 {
     nextreq_proxy_t *proxy = baton;
-    apr_status_t rv;
     
-    rv = proxy->nextreq(preq, proxy->baton, http, in_flight);
-    if (APR_SUCCESS == rv) req_init_cl(*preq);
-    return rv;
+    return proxy->nextreq(preq, proxy->baton, http, in_flight);
 }
 
 apr_status_t md_http_multi_perform(md_http_t *http, md_http_next_req *nextreq, void *baton)


### PR DESCRIPTION
libcurl 7.66.0 automatically adds a "Transfer-Encoding: chunked" header
if the content length is not known to libcurl, because of this change:
https://github.com/curl/curl/pull/4138

libcurl does not parse custom "Content-Length" headers, it needs the
content length using the options CURLOPT_POSTFIELDSIZE(_LARGE) and
CURLOPT_INFILESIZE(_LARGE).

The "Boulder" server rejects requests with both headers, but the host
acme-v02.api.letsencrypt.org accepts such requests, probably because
there's a reverse proxy.