### PR TITLE
Fixes a typo on NULL checking for sc->assigned structure

### DIFF
--- a/src/mod_md_ocsp.c
+++ b/src/mod_md_ocsp.c
@@ -62,7 +62,7 @@ apr_status_t md_ocsp_init_stapling_status(server_rec *s, apr_pool_t *p,
     sc = md_config_get(s);
     if (!staple_here(sc)) goto declined;
 
-    md = ((sc->assigned || sc->assigned->nelts == 1)?
+    md = ((sc->assigned && sc->assigned->nelts == 1)?
           APR_ARRAY_IDX(sc->assigned, 0, const md_t*) : NULL);
     rv = md_ocsp_prime(sc->mc->ocsp, md_cert_wrap(p, cert), 
                        md_cert_wrap(p, issuer), md);
@@ -85,7 +85,7 @@ apr_status_t md_ocsp_get_stapling_status(unsigned char **pder, int *pderlen,
     sc = md_config_get(s);
     if (!staple_here(sc)) goto declined;
     
-    md = ((sc->assigned || sc->assigned->nelts == 1)?
+    md = ((sc->assigned && sc->assigned->nelts == 1)?
           APR_ARRAY_IDX(sc->assigned, 0, const md_t*) : NULL);
     ap_log_cerror(APLOG_MARK, APLOG_TRACE2, 0, c, "get stapling for: %s", 
                   md? md->name : s->server_hostname);


### PR DESCRIPTION
Hello,

looking at ```staple_here``` function and NULL check as
```
if (sc->assigned 
        && sc->assigned->nelts == 1
...
```
it seems to me that these two usages of ```||``` are typos. I might just not be getting the point though...

mod_md builds and runs O.K. for me with httpd 2.4.x HEAD from yesterday; (Apache/2.4.42-dev, OpenSSL/1.1.1d) **although** I played just with Boulder locally... 
```
...
MDCertificateAuthority http://localhost:4000/directory
MDCertificateAgreement accepted
MDRequireHttps permanent
MDStapling on
MDStaplingKeepResponse 1d
MDStaplingRenewWindow 99%
MDCAChallenges tls-alpn-01
Protocols h2 http/1.1 acme-tls/1
...
```