### PR TITLE
Fixes test suite proxy auth config, Allow / Require

### DIFF
--- a/test/conf/proxy.conf.in
+++ b/test/conf/proxy.conf.in
@@ -7,9 +7,7 @@ Listen @HTTP_PROXY_PORT@
     ProxyVia On
 
     <Proxy *>
-        Order deny,allow
-        Deny from all
-        Allow from localhost
+        Require localhost
     </Proxy> 
 </VirtualHost>
 


### PR DESCRIPTION
The whole TS passes for me now:

    365 passed, 38 warnings in 374.00s (0:06:14)

i.e. it seems it fixed all 4 previously failing tests...

Linux x86_64, httpd 2.4.x HEAD from yesterday; (Apache/2.4.42-dev, OpenSSL/1.1.1d), Jansson v2.9

httpd built as:

```
./configure --prefix=/home/karm/workspaceRH/httpd-build
            --enable-mpms-shared=all --enable-brotli --enable-http2
            --enable-mods-shared=most --enable-maintainer-mode
            --with-expat=builtin  --enable-ssl  --enable-proxy
            --enable-proxy-http  --enable-proxy-ajp
            --with-brotli=/home/karm/workspaceRH/brotli-build
            --with-ssl=/home/karm/workspaceRH/openssl-build
            --with-nghttp2=/home/karm/workspaceRH/nghttp2-build
            --with-jansson=/home/karm/workspaceRH/jansson-build
```

WDYT? Can we safely assume contemporary httpd 2.4.x is used with master and replace Allow with Require or should I add httpd version check...? 