### PR TITLE
Adds CMake Windows build, removes mpm_winnt.h include from mod_md_os.c

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,4 @@ src/a2md
 /test/unit/main
 wiki
 test/conf/std_vhosts.conf
+build/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,70 @@
+# Copyright 2020 Contributors to mod_md project
+# 
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+# http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+PROJECT(mod_md C)
+CMAKE_MINIMUM_REQUIRED(VERSION 3.14)
+
+INCLUDE(CheckSymbolExists)
+
+IF(WIN32)
+    SET(CMAKE_C_FLAGS "/O2 /MD /W3 /Zi")
+    # TODO: Questionable...people might want to override -DCMAKE_C_FLAGS_DEBUG="..."
+    SET(CMAKE_C_FLAGS_DEBUG "${CMAKE_C_FLAGS}")
+    SET(CMAKE_C_FLAGS_RELEASE "${CMAKE_C_FLAGS}")
+ELSE()
+
+ENDIF()
+
+SET(CMAKE_MODULE_PATH ${CMAKE_SOURCE_DIR}/cmake/modules ${CMAKE_MODULE_PATH})
+
+SET(LIBRARY_OUTPUT_PATH ${CMAKE_BINARY_DIR}/modules)
+
+FIND_PACKAGE(OpenSSL REQUIRED)
+FIND_PACKAGE(CURL REQUIRED)
+FIND_PACKAGE(JANSSON REQUIRED)
+FIND_PACKAGE(APACHE REQUIRED)
+FIND_PACKAGE(APR REQUIRED)
+
+INCLUDE_DIRECTORIES(${APR_INCLUDE_DIR})
+INCLUDE_DIRECTORIES(${APRUTIL_INCLUDE_DIR})
+INCLUDE_DIRECTORIES(${APACHE_INCLUDE_DIR})
+INCLUDE_DIRECTORIES(${OPENSSL_INCLUDE_DIR})
+INCLUDE_DIRECTORIES(${CURL_INCLUDE_DIR})
+INCLUDE_DIRECTORIES(${JANSSON_INCLUDE_DIR})
+
+AUX_SOURCE_DIRECTORY(${CMAKE_SOURCE_DIR}/src SRC_LIST)
+ADD_LIBRARY(mod_md MODULE ${SRC_LIST})
+SET_TARGET_PROPERTIES(mod_md PROPERTIES PREFIX "")
+SET_TARGET_PROPERTIES(mod_md PROPERTIES SUFFIX ".so")
+
+TARGET_LINK_LIBRARIES(mod_md ${APR_LIBRARIES} ${APRUTIL_LIBRARIES} ${APACHE_LIBRARY} ${OPENSSL_LIBRARIES} ${CURL_LIBRARIES} ${JANSSON_LIBRARIES})
+
+MESSAGE(STATUS "")
+MESSAGE(STATUS "")
+MESSAGE(STATUS "mod_md configuration summary:")
+MESSAGE(STATUS "")
+MESSAGE(STATUS "  Build type ...................... : ${CMAKE_BUILD_TYPE}")
+MESSAGE(STATUS "  Install prefix .................. : ${CMAKE_INSTALL_PREFIX}")
+MESSAGE(STATUS "  C compiler ...................... : ${CMAKE_C_COMPILER}")
+MESSAGE(STATUS "  APR include directory ........... : ${APR_INCLUDE_DIR}")
+MESSAGE(STATUS "  APR libraries ................... : ${APR_LIBRARIES}")
+MESSAGE(STATUS "  APR Util include directory ...... : ${APRUTIL_INCLUDE_DIR}")
+MESSAGE(STATUS "  APR Util libraries .............. : ${APRUTIL_LIBRARIES}")
+MESSAGE(STATUS "  OpenSSL include directory ....... : ${OPENSSL_INCLUDE_DIR}")
+MESSAGE(STATUS "  OpenSSL libraries ............... : ${OPENSSL_LIBRARIES}")
+MESSAGE(STATUS "  Curl include directory........... : ${CURL_INCLUDE_DIR}")
+MESSAGE(STATUS "  Curl libraries................... : ${CURL_LIBRARIES}")
+MESSAGE(STATUS "  Jansson include directory.........: ${JANSSON_INCLUDE_DIR}")
+MESSAGE(STATUS "  Jansson libraries ............... : ${JANSSON_LIBRARIES}")
+MESSAGE(STATUS "")

--- a/README.md
+++ b/README.md
@@ -720,6 +720,29 @@ and restart ```httpd```.
 
 [@nono303](https://github.com/nono303) has builds available at his [github repository](https://github.com/nono303/mod_md).
 
+You can also build your own mod_md on Windows. Requirements: APR/APR Util (as likely comes with your httpd distro), OpenSSL, Curl, Jansson, Apache HTTP Server, CMake installation, Visual Studio installation. The undermentioned example is intended for development and debugging. Production build should be done in the context of httpd build, exactly with the libraries your httpd uses.
+
+
+```
+mkdir build
+cd build
+vcvars64
+cmake -G "NMake Makefiles"
+ -DOPENSSL_ROOT_DIR=C:/Users/Administrator/source/openssl/target/
+ -DCURL_LIBRARY=C:/Users/Administrator/source/curl-build/lib/libcurl_imp.lib
+ -DCURL_INCLUDE_DIR=C:/Users/Administrator/source/curl-build/include
+ -DAPACHE_ROOT_DIR=C:/Users/Administrator/source/Apache24/
+ -DAPR_ROOT_DIR=C:/Users/Administrator/source/Apache24/
+ -DAPRUTIL_ROOT_DIR=C:/Users/Administrator/source/Apache24/
+ -DJANSSON_ROOT_DIR=C:/Users/Administrator/source/jansson/build
+ -DCMAKE_BUILD_TYPE=Release ..
+
+nmake
+
+dir modules\
+mod_md.exp  mod_md.lib  mod_md.so*  mod_md.so.manifest
+```
+
 ## Fedora
 
 The plan in Fedora is to include v2.x of mod_md with Fedora 31, which is due to be released end of summer 2019.

--- a/cmake/modules/FindAPACHE.cmake
+++ b/cmake/modules/FindAPACHE.cmake
@@ -1,0 +1,51 @@
+# Copyright 2020 Contributors to mod_md project
+# 
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+# http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# One must set a hint: APACHE_ROOT_DIR
+# Module defines
+#  APACHE_FOUND         - System has APACHE
+#  APACHE_INCLUDE_DIR   - The APACHE include directory
+#  APACHE_LIBRARIES     - Library
+# Defined:
+#  APACHE_LIBRARY       - httpd lib
+
+IF(NOT APACHE_ROOT_DIR)
+    message(FATAL_ERROR "APACHE_ROOT_DIR is not set. We don't know where to look for APACHE, quitting.")
+ENDIF()
+FIND_PATH(APACHE_INCLUDE_DIR httpd.h
+    "${APACHE_ROOT_DIR}/include"
+)
+SET(APACHE_NAMES ${APACHE_NAMES} httpd libhttpd)
+FIND_LIBRARY(APACHE_LIBRARY NAMES ${APACHE_NAMES} PATHS "${APACHE_ROOT_DIR}/lib" "${APACHE_ROOT_DIR}/lib64")
+IF (APACHE_LIBRARY AND APACHE_INCLUDE_DIR)
+    SET(APACHE_LIBRARIES ${APACHE_LIBRARY})
+    SET(APACHE_FOUND "YES")
+ELSE (APACHE_LIBRARY AND APACHE_INCLUDE_DIR)
+    SET(APACHE_FOUND "NO")
+ENDIF (APACHE_LIBRARY AND APACHE_INCLUDE_DIR)
+
+IF (APACHE_FOUND)
+    IF (NOT APACHE_FIND_QUIETLY)
+        MESSAGE(STATUS "Found APACHE: ${APACHE_LIBRARIES}")
+    ENDIF (NOT APACHE_FIND_QUIETLY)
+ELSE (APACHE_FOUND)
+    IF (APACHE_FIND_REQUIRED)
+        MESSAGE(FATAL_ERROR "Could not find APACHE library")
+    ENDIF (APACHE_FIND_REQUIRED)
+ENDIF (APACHE_FOUND)
+
+MARK_AS_ADVANCED(
+        APACHE_LIBRARY
+        APACHE_INCLUDE_DIR
+)

--- a/cmake/modules/FindAPR.cmake
+++ b/cmake/modules/FindAPR.cmake
@@ -1,0 +1,90 @@
+# Copyright 2020 Contributors to mod_md project
+# 
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+# http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# One must set a hint: APR_ROOT_DIR, APRUTIL_ROOT_DIR
+# Find the APR includes and libraries
+# Module defines
+#   APR_INCLUDE_DIR and APRUTIL_INCLUDE_DIR, apr.h, etc.
+#   APR_LIBRARIES and APRUTIL_LIBRARIES, libs needed to use APR.
+#   APR_FOUND and APRUTIL_FOUND, whether APR usable.
+# Defined:
+#   APR_LIBRARY and APRUTIL_LIBRARY, where to find the APR library.
+
+IF(NOT APR_ROOT_DIR)
+    message(FATAL_ERROR "APR_ROOT_DIR is not set. We don't know where to look for APR, quitting.")
+ENDIF()
+
+IF(NOT APRUTIL_ROOT_DIR)
+    message(FATAL_ERROR "APR_ROOT_DIR is not set. We don't know where to look for APR, quitting.")
+ENDIF()
+
+FIND_PATH(APR_INCLUDE_DIR apr.h
+    "${APR_ROOT_DIR}/include"
+)
+SET(APR_NAMES ${APR_NAMES} libapr-1 apr-1)
+FIND_LIBRARY(APR_LIBRARY NAMES ${APR_NAMES} PATHS "${APR_ROOT_DIR}/lib" "${APR_ROOT_DIR}/lib64")
+IF (APR_LIBRARY AND APR_INCLUDE_DIR)
+    SET(APR_LIBRARIES ${APR_LIBRARY})
+    SET(APR_FOUND "YES")
+ELSE (APR_LIBRARY AND APR_INCLUDE_DIR)
+    SET(APR_FOUND "NO")
+ENDIF (APR_LIBRARY AND APR_INCLUDE_DIR)
+
+IF (APR_FOUND)
+    IF (NOT APR_FIND_QUIETLY)
+        MESSAGE(STATUS "Found APR: ${APR_LIBRARIES}")
+    ENDIF (NOT APR_FIND_QUIETLY)
+ELSE (APR_FOUND)
+    IF (APR_FIND_REQUIRED)
+        MESSAGE(FATAL_ERROR "Could not find APR library")
+    ENDIF (APR_FIND_REQUIRED)
+ENDIF (APR_FOUND)
+
+MARK_AS_ADVANCED(
+        APR_LIBRARY
+        APR_INCLUDE_DIR
+)
+
+# APR Util
+FIND_PATH(APRUTIL_INCLUDE_DIR apu.h
+    "${APRUTIL_ROOT_DIR}/include"
+)
+
+SET(APRUTIL_NAMES ${APRUTIL_NAMES} libaprutil-1 aprutil-1)
+FIND_LIBRARY(APRUTIL_LIBRARY
+        NAMES ${APRUTIL_NAMES}
+        PATHS "${APRUTIL_ROOT_DIR}/lib" "${APRUTIL_ROOT_DIR}/lib64"
+)
+
+IF (APRUTIL_LIBRARY AND APRUTIL_INCLUDE_DIR)
+    SET(APRUTIL_LIBRARIES ${APRUTIL_LIBRARY})
+    SET(APRUTIL_FOUND "YES")
+ELSE (APRUTIL_LIBRARY AND APRUTIL_INCLUDE_DIR)
+    SET(APRUTIL_FOUND "NO")
+ENDIF (APRUTIL_LIBRARY AND APRUTIL_INCLUDE_DIR)
+
+IF (APRUTIL_FOUND)
+    IF (NOT APRUTIL_FIND_QUIETLY)
+        MESSAGE(STATUS "Found APRUTIL: ${APRUTIL_LIBRARIES}")
+    ENDIF (NOT APRUTIL_FIND_QUIETLY)
+ELSE (APRUTIL_FOUND)
+    IF (APRUTIL_FIND_REQUIRED)
+        MESSAGE(FATAL_ERROR "Could not find APRUTIL library")
+    ENDIF (APRUTIL_FIND_REQUIRED)
+ENDIF (APRUTIL_FOUND)
+
+MARK_AS_ADVANCED(
+        APRUTIL_LIBRARY
+        APRUTIL_INCLUDE_DIR
+)

--- a/cmake/modules/FindJANSSON.cmake
+++ b/cmake/modules/FindJANSSON.cmake
@@ -1,0 +1,53 @@
+# Copyright 2020 Contributors to mod_md project
+# 
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+# http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# One must set a hint: JANSSON_ROOT_DIR
+# Once done this will define
+#  JANSSON_FOUND
+#  JANSSON_INCLUDE_DIRS
+#  JANSSON_LIBRARIES
+
+IF(NOT JANSSON_ROOT_DIR)
+    message(FATAL_ERROR "JANSSON_ROOT_DIR is not set. We don't know where to look for JANSSON, quitting.")
+ENDIF()
+
+
+FIND_PATH(JANSSON_INCLUDE_DIR jansson.h
+    "${JANSSON_ROOT_DIR}/include"
+)
+
+SET(JANSSON_NAMES ${JANSSON_NAMES} jansson libjansson)
+FIND_LIBRARY(JANSSON_LIBRARY NAMES ${JANSSON_NAMES} PATHS "${JANSSON_ROOT_DIR}/lib" "${JANSSON_ROOT_DIR}/lib64")
+
+IF (JANSSON_LIBRARY AND JANSSON_INCLUDE_DIR)
+    SET(JANSSON_LIBRARIES ${JANSSON_LIBRARY})
+    SET(JANSSON_FOUND "YES")
+ELSE (JANSSON_LIBRARY AND JANSSON_INCLUDE_DIR)
+    SET(JANSSON_FOUND "NO")
+ENDIF (JANSSON_LIBRARY AND JANSSON_INCLUDE_DIR)
+
+IF (JANSSON_FOUND)
+    IF (NOT JANSSON_FIND_QUIETLY)
+        MESSAGE(STATUS "Found JANSSON: ${JANSSON_LIBRARIES}")
+    ENDIF (NOT JANSSON_FIND_QUIETLY)
+ELSE (JANSSON_FOUND)
+    IF (JANSSON_FIND_REQUIRED)
+        MESSAGE(FATAL_ERROR "Could not find JANSSON library")
+    ENDIF (JANSSON_FIND_REQUIRED)
+ENDIF (JANSSON_FOUND)
+
+MARK_AS_ADVANCED(
+        JANSSON_LIBRARY
+        JANSSON_INCLUDE_DIR
+)

--- a/src/mod_md_os.c
+++ b/src/mod_md_os.c
@@ -25,9 +25,6 @@
 #if APR_HAVE_UNISTD_H
 #include <unistd.h>
 #endif
-#ifdef WIN32
-#include "mpm_winnt.h"
-#endif
 #if AP_NEED_SET_MUTEX_PERMS
 #include "unixd.h"
 #endif


### PR DESCRIPTION
# Windows CMake build support

Hello, I would like to eventually make the test harness to run smoothly on Windows for me and I figured this PR would make it easier for everybody to do a Windows build.

## CMake files

It is fairly rudimentary,  but it works. There is no magic logic in finding dependencies, e.g. one has to provide path to JANSSON root dir where /lib and /include are expected.

See README for usage.

## mod_md_os.c and mpm_winnt.h

As I tested it with Apache Lounge's [Apache 2.4.41 Win64](https://www.apachelounge.com/download/VS16/binaries/httpd-2.4.41-win64-VS16.zip), it struck me that they don't provide mpm_winnt.h. I tried to remove it and it apparently is not used... In other words, my smoke test works without it :smiley:. I welcome second opinion on this move.

## Tested

I used the undermentioned configuration to test it on Windows 2019 Server with Apache Lounge's [Apache 2.4.41 Win64](https://www.apachelounge.com/download/VS16/binaries/httpd-2.4.41-win64-VS16.zip):

```
SSLCipherSuite HIGH:MEDIUM:!MD5:!RC4:!3DES
SSLProxyCipherSuite HIGH:MEDIUM:!MD5:!RC4:!3DES
SSLProtocol TLSv1.3 +TLSv1.2
SSLProxyProtocol TLSv1.3 +TLSv1.2
SSLPassPhraseDialog builtin
SSLSessionCache "shmcb:C:/Users/Administrator/source/Apache24/logs/ssl_scache(512000)"
SSLSessionCacheTimeout 300
SSLUseStapling On
SSLStaplingCache "shmcb:C:/Users/Administrator/source/Apache24/logs/ssl_stapling(32768)"
SSLStaplingStandardCacheTimeout 3600
SSLStaplingErrorCacheTimeout 600

MDCertificateAuthority http://boulder:4000/directory
MDCertificateAgreement accepted

MDRequireHttps permanent
MDStapling on
MDStaplingKeepResponse 1d
MDStaplingRenewWindow 99%

MDCAChallenges tls-alpn-01
Protocols h2 http/1.1 acme-tls/1

Listen 5001

MDPortMap 80:7070 443:5001

<Location "/server-status">
    SetHandler server-status
</Location>
<Location "/md-status">
    SetHandler md-status
</Location>

<Directory "C:/Users/Administrator/source/Apache24/docs">
    Options Indexes FollowSymLinks
    AllowOverride None
    Require all granted
</Directory>

MDomain host1.gugu1.cz www.host1.gugu1.cz
<VirtualHost *:5001>
    SSLEngine on
    DocumentRoot "C:/Users/Administrator/source/Apache24/docs"
    ServerName host1.gugu1.cz
    ServerAlias www.host1.gugu1.cz
    ServerAdmin me@host1.gugu1.cz
</VirtualHost>
```

Hostnames: C:\Windows\System32\drivers\etc\hosts

```
 192.168.122.1 boulder
 192.168.42.95 this-test-machine.org
 192.168.42.95 host1.gugu1.cz
 192.168.42.95 www.host1.gugu1.cz
```
where  192.168.122.1 is the system running Boulder and 192.168.42.95 is the Windows server.

Ad OCSP: I forwarded it:
```
netsh interface portproxy add v4tov4 listenaddress=127.0.0.1 listenport=4002 connectaddress=192.168.122.1 connectport=4002
```

See attached [error.log](https://github.com/icing/mod_md/files/4035802/error.log) from the test. Apache is started, stopped, started again and Firefox is used to access the page. Looks good to me...

![firefox](https://user-images.githubusercontent.com/691097/71987329-48d4a000-322e-11ea-9402-a25128b6c0a1.png)

Thank you for your review and additional comments and ideas. 


