### PR TITLE
Improve protocol check for pre-configured "tls-alpn-01" challenge

### DIFF
--- a/src/mod_md.c
+++ b/src/mod_md.c
@@ -436,9 +436,10 @@ static server_rec *get_public_https_server(md_t *md, const char *domain, server_
     md_srv_conf_t *sc;
     md_mod_conf_t *mc;
     server_rec *s;
+    server_rec *res = NULL;
     request_rec r;
     int i;
-    int skip_port_check = 0;
+    int check_port = 1;
 
     sc = md_config_get(base_server);
     mc = sc->mc;
@@ -446,27 +447,37 @@ static server_rec *get_public_https_server(md_t *md, const char *domain, server_
 
     if (md->ca_challenges && md->ca_challenges->nelts > 0) {
         /* skip the port check if "tls-alpn-01" is pre-configured */
-        skip_port_check = md_array_str_index(md->ca_challenges, MD_AUTHZ_TYPE_TLSALPN01, 0, 0) >= 0;
+        check_port = !(md_array_str_index(md->ca_challenges, MD_AUTHZ_TYPE_TLSALPN01, 0, 0) >= 0);
     }
 
-    if (!skip_port_check && !mc->can_https) return NULL;
+    if (check_port && !mc->can_https) return NULL;
 
     /* find an ssl server matching domain from MD */
     for (s = base_server; s; s = s->next) {
         sc = md_config_get(s);
         if (!sc || !sc->is_ssl || !sc->assigned) continue;
         if (base_server == s && !mc->manage_base_server) continue;
-        if (base_server != s && !skip_port_check && mc->local_443 > 0 && !uses_port(s, mc->local_443)) continue;
+        if (base_server != s && check_port && mc->local_443 > 0 && !uses_port(s, mc->local_443)) continue;
         for (i = 0; i < sc->assigned->nelts; ++i) {
             if (md == APR_ARRAY_IDX(sc->assigned, i, md_t*)) {
                 r.server = s;
                 if (ap_matches_request_vhost(&r, domain, s->port)) {
-                    return s;
+                    if (check_port) {
+                        return s;
+                    }
+                    else {
+                        /* there may be multiple matching servers because we ignore the port.
+                           if possible, choose a server that supports the acme-tls/1 protocol */
+                        if (ap_is_allowed_protocol(NULL, NULL, s, PROTO_ACME_TLS_1)) {
+                            return s;
+                        }
+                        res = s;
+                    }
                 }
             }
         }
     }
-    return NULL;
+    return res;
 }
 
 static apr_status_t auto_add_domains(md_t *md, server_rec *base_server, apr_pool_t *p)


### PR DESCRIPTION
For "tls-alpn-01" challenges, mod_md checks whether there is a server
that supports the "acme-tls/1" protocol.

If the challenge "tls-alpn-01" is pre-configured with MDCAChallenges,
the ports of the servers are ignored (see issue #133). If there are
multiple servers matching a domain name, don't just look at the first
server but search one that supports the "acme-tls/1" protocol.

This is a follow-up to https://github.com/icing/mod_md/pull/159 and
https://github.com/icing/mod_md/issues/133