### PR TITLE
Add MDContactEmail directive

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ mod_md.xcodeproj/xcuserdata/*.xcuserdatad
 *.lo
 *.la
 *.pcap
+*~
 .libs
 .configured
 .deps
@@ -21,6 +22,7 @@ config.sub
 config.h
 config.h.in
 config.h.in~
+config.cache
 configure
 configure.scan
 depcomp

--- a/Build.from-git
+++ b/Build.from-git
@@ -1,0 +1,35 @@
+Building mod_md from the git repository
+
+You can build in Docker using Dockerfile in the git repository.
+
+If you don't have/don't want to use Docker, the following procedure
+will build it outside docker.
+
+Prerequisites:
+ o Assumes you have built httpd from source
+ o Install libjansson
+   - From your distro - libjansson-dev
+   - From source: http://www.digip.org/jansson
+ o Install libcurl-dev (e.g libcurl4-openssl-dev, or https://curl.haxx.se/download.html)
+
+Procedure:
+
+git clone https://github.com/icing/mod_md.git
+
+autoreconf -i
+automake
+autoconf
+./configure -C --with-apxs=/usr/local/bin/apxs
+make
+make install
+
+To use this mod_md, you need to enable it in some
+distribution-specific manner.
+
+For bare httpd, your configuration should include:
+
+LoadModule ssl_module modules/mod_ssl.so
+LoadModule watchdog_module /usr/local/lib/httpd/modules/mod_watchdog.so
+LoadModule md_module /usr/local/lib/httpd/modules/mod_md.so
+
+See the mod_md README for details on configuring mod_md.

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,6 @@
+v2.2.next
+ * Prefer MDContactEmail directive to ServerAdmin for registration
+
 v2.2.6
 ----------------------------------------------------------------------------------------------------
  * Michal Karm Babacek (@Karm) added `cmake` support, especially valuable under Windows.

--- a/README.md
+++ b/README.md
@@ -114,6 +114,8 @@ One more thing. There is usually an email address in your Apache configuration, 
 
 `mod_md` will use that email address when registering your domains at Let's Encrypt. And they will try to contact you with important news, should the need arise. So, make sure this is a real address that you monitor! 
 
+If you want to be registered and contacted different email address, specify it with the MDContactEmail directive, which is preferred.
+
 As the last thing, add the following line somewhere in your configuration:
 
 ```
@@ -1776,7 +1778,9 @@ It is therefore advisable to first test the ```MDRequireHttps temporary``` confi
 Default: `md`
 
 This is where `mod_md` will store all the files (i.e. account key, private keys and certs etc.)<BR/>
-The path is relevant to `ServerRoot`.
+The path is relative to `ServerRoot`.
+
+Note that if you run multiple instances of `httpd`, each instance must have it's own directory.  
 
 ## MDBaseServer
 
@@ -1878,9 +1882,9 @@ Certificate Monitors offer supervision of Certificate Transparency (CT) Logs to
 track the use of certificates for domains. The least you may see is that Let's Encrypt (or whichever
 CA you have configured) has entered your certificates into the CTLogs.
 
-## ServerAdmin / Contact Information
+## MDContactEmail / Contact Information
 
-Also, the ACME protocol requires you to give a contact url when you sign up. Currently, Let's Encrypt wants an email address (and it will use it to inform you about renewals or changed terms of service). ```mod_md``` uses the ```ServerAdmin``` email in your Apache configuration, so please specify the correct address there.
+The ACME protocol requires you to give a contact url when you sign up. Currently, Let's Encrypt wants an email address (and it will use it to inform you about renewals or changed terms of service). ```mod_md``` uses the ```MDContactEmail``` directive email in your Apache configuration, so please specify the correct address there.  If ```MDContactEmail``` is not present, ```mod_md``` will use the ```ServerAdmin```  directive.
 
 
 # Test Suite

--- a/src/md_acme_drive.c
+++ b/src/md_acme_drive.c
@@ -132,7 +132,7 @@ apr_status_t md_acme_drive_set_acct(md_proto_driver_t *d, md_result_t *result)
         if (!ad->md->contacts || apr_is_empty_array(md->contacts)) {
             rv = APR_EINVAL;
             md_result_printf(result, rv, "No contact information is available for MD %s. "
-                             "Configure one using the ServerAdmin directive.", md->name);            
+                             "Configure one using the MDContactEmail or ServerAdmin directive.", md->name);            
             md_result_log(result, MD_LOG_ERR);
             goto leave;
         }

--- a/src/mod_md_config.h
+++ b/src/mod_md_config.h
@@ -25,6 +25,7 @@ struct md_pkey_spec_t;
 
 typedef enum {
     MD_CONFIG_CA_URL,
+    MD_CONFIG_CA_CONTACT,
     MD_CONFIG_CA_PROTO,
     MD_CONFIG_BASE_DIR,
     MD_CONFIG_CA_AGREEMENT,
@@ -85,6 +86,7 @@ typedef struct md_srv_conf_t {
     md_timeslice_t *warn_window;  /* time before expiration that warning are sent out */
     
     const char *ca_url;                /* url of CA certificate service */
+    const char *ca_contact;            /* contact email registered to account */
     const char *ca_proto;              /* protocol used vs CA (e.g. ACME) */
     const char *ca_agreement;          /* accepted agreement uri between CA and user */ 
     struct apr_array_header_t *ca_challenges; /* challenge types configured */


### PR DESCRIPTION
This pull request includes code to implement the `MDContactEmail` directive, which separates the contact email from the `ServerAdmin`.  See #174.

It still defaults to `ServerAdmin`, so it should be backward compatible with existing configurations.  Defaulting to `ServerAdmin` also means that simple configurations don't require `MDContactEmail`.

I also documented how to build `mod_md` from a `git` clone, and tweaked `.gitignore`.

So far, this works for me, but could use more testing...
