### PR TITLE
[WIP] Fixes & issues for 2.3.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,6 +38,7 @@ mod_md-*.tar.gz
 m4
 .cache
 src/a2md
+a2md.1
 
 # Automake test-suite artifacts
 /test-driver

--- a/ChangeLog
+++ b/ChangeLog
@@ -3,6 +3,7 @@ V2.3.next
  * Fix lowercasing of filenames
  * Improved format of Managed Certificate Status
  * Provide fallback certificates for all key types requested in MDPrivateKeys
+ * Update /.httpd/certificate-status to correctly handle multiple keys
 
 v2.3.0 (BETA)
 ----------------------------------------------------------------------------------------------------

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,9 @@
+V2.3.next
+----------------------------------------------------------------------------------------------------
+ * Fix lowercasing of filenames
+ * Improved format of Managed Certificate Status
+ * Provide fallback certificates for all key types requested in MDPrivateKeys
+
 v2.3.0 (BETA)
 ----------------------------------------------------------------------------------------------------
  * MDPrivateKeys checks for duplicate key specifications. There can only be one RSA key

--- a/README.md
+++ b/README.md
@@ -934,10 +934,17 @@ upcoming certificates on a domain. You invoke it like this:
 ```
 > curl https://eissing.org/.httpd/certificate-status
 {
-  "valid-from": "Mon, 01 Apr 2019 06:47:43 GMT",
-  "valid-until": "Sun, 30 Jun 2019 06:47:43 GMT",
+  "rsa": {
+    "valid": {
+      "from": "Mon, 01 Apr 2019 06:47:43 GMT",
+      "until": "Sun, 30 Jun 2019 06:47:43 GMT"
+  },
   "serial": "03D02EDA041CB95BF23B030C308FDE0B35B7",
   "sha256-fingerprint" : "xx:yy:zz:..."
+  },
+  "P-256": {
+    ...
+  }
 }
 ```
 
@@ -949,16 +956,29 @@ When a new certificate has been obtained, but is not activated yet, this will sh
 
 ```
 {
-  "valid-from": "Mon, 01 Apr 2019 06:47:43 GMT",
-  "valid-until": "Sun, 30 Jun 2019 06:47:43 GMT",
-  "serial": "03D02EDA041CB95BF23B030C308FDE0B35B7"
+  "rsa": {
+    "valid": {
+      "from": "Mon, 01 Apr 2019 06:47:43 GMT",
+      "until": "Sun, 30 Jun 2019 06:47:43 GMT"
+  },
+  "serial": "03D02EDA041CB95BF23B030C308FDE0B35B7",
   "sha256-fingerprint" : "xx:yy:zz:..."
   "renewal": {
-    "valid-from": "Tue, 21 May 2019 11:53:59 GMT",
-    "valid-until": "Mon, 19 Aug 2019 11:53:59 GMT",
-    "serial": "FFC16E5FEFBE90805AC153D70EF9E8D3873A",
-    "sha256-fingerprint" : "aa:bb:cc:..."
+	"name": "example.net",
+        "finished": true,
+        "notified": false,
+        "last-run": "Thu, 02 May 2019 21:54:22 GMT",
+        "errors": 0,
+        "last": {
+          "status": 0,
+          "detail": "certificate status is GOOD, status valid Mon, 01 Apr 2019 06:47:43 GMT - Sun, 30 Jun 2019 06:47:43 GMT",
+          "activity": "status of certid xxyyzzqq, reading response"
+    }
+  },
+  "P-256": {
+    ...
   }
+}
 ```
 with `renewal` giving the properties of the new certificate, once it has been obtained. This can
 be exposed publicly as well, since - once the server is reloaded, it is part of every TLS connection.

--- a/src/md_store.c
+++ b/src/md_store.c
@@ -256,14 +256,15 @@ typedef struct {
 
 static const char *pk_filename(const char *keyname, const char *base, apr_pool_t *p)
 {
-    char *s;
+    char *s, *t;
     /* We also run on various filesystems with difference upper/lower preserve matching
      * rules. Normalize the names we use, since private key specifications are basically
      * user input. */
     s = (keyname && apr_strnatcasecmp("rsa", keyname))?
         apr_pstrcat(p, base, ".", keyname, ".pem", NULL)
         : apr_pstrcat(p, base, ".pem", NULL);
-    apr_tolower(s);
+    for (t = s; *t; t++ )
+        *t = apr_tolower(*t);
     return s;
 }
 

--- a/src/md_store.h
+++ b/src/md_store.h
@@ -78,8 +78,8 @@ typedef enum {
 #define MD_FN_CERT              "cert.pem"
 #define MD_FN_HTTPD_JSON        "httpd.json"
 
-#define MD_FN_FALLBACK_PKEY     "fallback-privkey.pem"
-#define MD_FN_FALLBACK_CERT     "fallback-cert.pem"
+#define MD_FN_FALLBACK_PKEY     "fallback-%s"
+#define MD_FN_FALLBACK_CERT     "fallback-%s"
 
 /**
  * Load the JSON value at key "group/name/aspect", allocated from pool p.

--- a/src/mod_md_status.c
+++ b/src/mod_md_status.c
@@ -395,7 +395,7 @@ static int cert_check_iter(void *baton, const char *key, md_json_t *json)
     fingerprint = md_json_gets(json, MD_KEY_SHA256_FINGERPRINT, NULL);
     if (fingerprint) {
         apr_brigade_printf(ctx->bb, NULL, NULL, 
-                           "<a href=\"%s%s\">%s[%s]</a> ", 
+                           "<a href=\"%s%s\">%s[%s]</a><br>", 
                            ctx->mc->cert_check_url, fingerprint, 
                            ctx->mc->cert_check_name, key);
     }
@@ -445,6 +445,13 @@ static void add_json_val(status_ctx *ctx, md_json_t *j)
     }
 }
 
+static void si_val_names(status_ctx *ctx, md_json_t *mdj, const status_info *info)
+{
+    apr_brigade_puts(ctx->bb, NULL, NULL, "<div style=\"max-width:400px;\">");
+    add_json_val(ctx, md_json_getj(mdj, info->key, NULL));
+    apr_brigade_puts(ctx->bb, NULL, NULL, "</div>");
+}
+
 static void add_status_cell(status_ctx *ctx, md_json_t *mdj, const status_info *info)
 {
     if (info->fn) {
@@ -457,7 +464,7 @@ static void add_status_cell(status_ctx *ctx, md_json_t *mdj, const status_info *
 
 static const status_info status_infos[] = {
     { "Domain", MD_KEY_NAME, NULL },
-    { "Names", MD_KEY_DOMAINS, NULL },
+    { "Names", MD_KEY_DOMAINS, si_val_names },
     { "Status", MD_KEY_STATE, si_val_status },
     { "Valid", MD_KEY_CERT, si_val_cert_valid_time },
     { "CA", MD_KEY_CA, si_val_ca_url },

--- a/src/mod_md_status.c
+++ b/src/mod_md_status.c
@@ -58,7 +58,8 @@
 
 int md_http_cert_status(request_rec *r)
 {
-    md_json_t *resp, *j, *mdj, *certj;
+    int i;
+    md_json_t *resp, *mdj;
     const md_srv_conf_t *sc;
     const md_t *md;
     md_pkey_spec_t *spec;
@@ -98,30 +99,40 @@ int md_http_cert_status(request_rec *r)
                   "status for MD: %s is %s", md->name, md_json_writep(mdj, r->pool, MD_JSON_FMT_INDENT));
 
     resp = md_json_create(r->pool);
-    if (md_json_has_key(mdj, MD_KEY_CERT, MD_KEY_VALID, NULL)) {
-        md_json_setj(md_json_getj(mdj, MD_KEY_CERT, MD_KEY_VALID, NULL), resp, MD_KEY_VALID, NULL);
+
+    for (i = 0; i < md_pkeys_spec_count(md->pks); ++i) {
+        md_json_t *cj;
+
+        spec = md_pkeys_spec_get(md->pks, i);
+        keyname = md_pkey_spec_name(spec);
+        cj = md_json_create(r->pool);
+
+        if (md_json_has_key(mdj, MD_KEY_CERT, keyname, MD_KEY_VALID, NULL)) {
+            md_json_setj(md_json_getj(mdj, MD_KEY_CERT, keyname, MD_KEY_VALID, NULL),
+                         cj, MD_KEY_VALID, NULL);
+        }
+
+        if (md_json_has_key(mdj, MD_KEY_CERT, keyname, MD_KEY_SERIAL, NULL)) {
+            md_json_sets(md_json_gets(mdj, MD_KEY_CERT, keyname, MD_KEY_SERIAL, NULL),
+                         cj, MD_KEY_SERIAL, NULL);
+        }
+        if (md_json_has_key(mdj, MD_KEY_CERT, keyname, MD_KEY_SHA256_FINGERPRINT, NULL)) {
+            md_json_sets(md_json_gets(mdj, MD_KEY_CERT, keyname, MD_KEY_SHA256_FINGERPRINT, NULL),
+                         cj, MD_KEY_SHA256_FINGERPRINT, NULL);
+        }
+    
+        if (md_json_has_key(mdj, MD_KEY_CERT, keyname, MD_KEY_RENEWAL, NULL)) {
+            md_json_t *certj, *j;
+            /* copy over the information we want to make public about this:
+             *  - when not finished, add an empty object to indicate something is going on
+             *  - when a certificate is staged, add the information from that */
+            certj = md_json_getj(mdj, MD_KEY_CERT, keyname, MD_KEY_RENEWAL, NULL);
+            j = certj? certj : md_json_create(r->pool);
+            md_json_setj(j, cj, MD_KEY_RENEWAL, NULL);
+        }
+        md_json_setj(cj, resp, keyname, NULL );
     }
 
-    spec = md_pkeys_spec_get(md->pks, 0);
-    keyname = md_pkey_spec_name(spec);
-    if (md_json_has_key(mdj, MD_KEY_CERT, keyname, MD_KEY_SERIAL, NULL)) {
-        md_json_sets(md_json_gets(mdj, MD_KEY_CERT, keyname, MD_KEY_SERIAL, NULL), 
-                     resp, MD_KEY_SERIAL, NULL);
-    }
-    if (md_json_has_key(mdj, MD_KEY_CERT, keyname, MD_KEY_SHA256_FINGERPRINT, NULL)) {
-        md_json_sets(md_json_gets(mdj, MD_KEY_CERT, keyname, MD_KEY_SHA256_FINGERPRINT, NULL), 
-                     resp, MD_KEY_SHA256_FINGERPRINT, NULL);
-    }
-    
-    if (md_json_has_key(mdj, MD_KEY_RENEWAL, NULL)) {
-        /* copy over the information we want to make public about this:
-         *  - when not finished, add an empty object to indicate something is going on
-         *  - when a certificate is staged, add the information from that */
-        certj = md_json_getj(mdj, MD_KEY_RENEWAL, MD_KEY_CERT, NULL);
-        j = certj? certj : md_json_create(r->pool);; 
-        md_json_setj(j, resp, MD_KEY_RENEWAL, MD_KEY_CERT, NULL);
-    }
-    
     ap_log_rerror(APLOG_MARK, APLOG_TRACE2, 0, r, "md[%s]: sending status", md->name);
     apr_table_set(r->headers_out, "Content-Type", "application/json"); 
     bb = apr_brigade_create(r->pool, r->connection->bucket_alloc);


### PR DESCRIPTION
I updated one of my simpler configs with 2.3.0 Beta (actually, from master).  It had never run `mod_md` before.

It mostly works, but of course I found a few divotsL:

I will add commits and comments here as I debug.

## Fixed:
 - filename lowercasing assumed apr_tolower() works on a string; it works on a single character.
 - The `Check@` column of **Managed Certificates** status is hard to read with more than one key type..  I added a break
 - With any significant number of names, the other columns of te **Managed Certificates** table become compressed.  I added a limit that seems reasonable - it can be tuned.
 - Fallback certificates were only created for RSA, not all those specified in `MDPriivateKeys`
 - /.httpd/certificate-status contains only the RSA cert status, nothing on the EC
## Open:
 - SeLinux issues left staging area with incorrect permissions.  When fixed, `mod_md` did not recover.  I deleted the ServerRoot/md tree - but perhaps `mod_md` should recover.  In any case, the logging did not point me to the files/directories that were blocked.
 - The OCSP status is hard for humans to make sense of.  The certificate ID is a poor identifer.  Can we at least add the key type or (better) the CN (or first SAN if no CN)?
 - I had to delete the certificates database directories as well as stop/start `httpd` to switch from staging to the live LE certificates.  "graceful" did not suffice.

The `mod_md` config is quite simple:
````
  21: MDCertificateAuthority "https://acme-v02.api.letsencrypt.org/directory"
  23: MDCertificateProtocol "ACME"
  24: MDCertificateAgreement "accepted"
  26: MDPortMap http:-
  27: MDCAChallenges tls-alpn-01
  35: MDPrivateKeys RSA 4096 P-384
  36: MDRenewMode auto
  38: MDStapling on
  39: MDStapleOthers on
  41: MDServerStatus on
  43: MDCertificateStatus on
  59: MDContactEmail "security+md-wiki@litts.net"
  62: <MDomain wikiworld.litts.net>
  63:   MDMembers auto
    : </MDomain>
````
(There is also a `Protocols` directive including `acme-tls/1`)

More later.
