### PR TITLE
Revert a2md change, more bug fixes

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,6 +1,5 @@
 v2.3.next
 ----------------------------------------------------------------------------------------------------
- * a2md now has options to specify the trusted root certificates used when contacting the CA
  * ACME problem reports from CAs that include parameters in the Content-Type header are handled correctly.
    (Previously, the problem text would not be reported and retries could exist CA limits.)
  * Account Update transactions to V2 CAs now use the correct POST-AS-GET method.  Previously, an

--- a/a2md.xml
+++ b/a2md.xml
@@ -124,23 +124,7 @@
           </term>
           <listitem><simpara>You agree to the terms of services (url)</simpara></listitem>
        </varlistentry>
-
-       <varlistentry>
-          <term>
-             <option>-T</option> <replaceable>arg</replaceable>,
-             <option>--trust</option> <replaceable>arg</replaceable>
-          </term>
-          <listitem><simpara>File containing certificates fo the CAs you trust. See OpenSSL verify -CAfile.</simpara></listitem>
-       </varlistentry>
        
-       <varlistentry>
-          <term>
-             <option>-P</option> <replaceable>arg</replaceable>,
-             <option>--trustdir</option> <replaceable>arg</replaceable>
-          </term>
-          <listitem><simpara>Directory containing certificates fo the CAs you trust. Filenames must be hashed with c_rehash - See OpenSSL verify -CApath.</simpara></listitem>
-       </varlistentry>
-
        <varlistentry>
           <term>
              <option>-v</option>, 

--- a/src/md_acme.c
+++ b/src/md_acme.c
@@ -165,7 +165,8 @@ static apr_status_t inspect_problem(md_acme_req_t *req, const md_http_response_t
     md_json_t *problem;
     
     ctype = apr_table_get(req->resp_hdrs, "content-type");
-    if (ctype && !strncmp(ctype, "application/problem+json", 24 )) {
+    ctype = md_util_parse_ct(res->req->pool, ctype);
+    if (ctype && !strcmp(ctype, "application/problem+json")) {
         /* RFC 7807 */
         md_json_read_http(&problem, req->p, res);
         if (problem) {

--- a/src/md_acme.c
+++ b/src/md_acme.c
@@ -162,14 +162,15 @@ apr_status_t md_acme_init(apr_pool_t *p, const char *base,  int init_ssl)
 static apr_status_t inspect_problem(md_acme_req_t *req, const md_http_response_t *res)
 {
     const char *ctype;
-    md_json_t *problem;
-    
+    md_json_t *problem = NULL;
+    apr_status_t rv;
+
     ctype = apr_table_get(req->resp_hdrs, "content-type");
     ctype = md_util_parse_ct(res->req->pool, ctype);
     if (ctype && !strcmp(ctype, "application/problem+json")) {
         /* RFC 7807 */
-        md_json_read_http(&problem, req->p, res);
-        if (problem) {
+        rv = md_json_read_http(&problem, req->p, res);
+        if (rv == APR_SUCCESS && problem) {
             const char *ptype, *pdetail;
             
             req->resp_json = problem;
@@ -573,7 +574,7 @@ apr_status_t md_acme_use_acct(md_acme_t *acme, md_store_t *store,
             rv = md_acme_acct_validate(acme, store, p);
         }
         else {
-            /* account is from a nother server or, more likely, from another
+            /* account is from another server or, more likely, from another
              * protocol endpoint on the same server */
             rv = APR_ENOENT;
         }

--- a/src/md_acme_authz.c
+++ b/src/md_acme_authz.c
@@ -250,11 +250,11 @@ static apr_status_t on_init_authz_resp(md_acme_req_t *req, void *baton)
     jpayload = md_json_create(req->p);
     if (MD_ACME_VERSION_MAJOR(req->acme->version) <= 1) {
         md_json_sets(MD_KEY_CHALLENGE, jpayload, MD_KEY_RESOURCE, NULL);
+        if (ctx->challenge->key_authz) {
+            md_json_sets(ctx->challenge->key_authz, jpayload, MD_KEY_KEYAUTHZ, NULL);
+        }
     }
-    if (ctx->challenge->key_authz) {
-        md_json_sets(ctx->challenge->key_authz, jpayload, MD_KEY_KEYAUTHZ, NULL);
-    }
-    
+
     return md_acme_req_body_init(req, jpayload);
 } 
 

--- a/src/md_acme_drive.c
+++ b/src/md_acme_drive.c
@@ -201,6 +201,7 @@ static apr_status_t add_http_certs(apr_array_header_t *chain, apr_pool_t *p,
     const char *ct;
     
     ct = apr_table_get(res->headers, "Content-Type");
+    ct = md_util_parse_ct(res->req->pool, ct);
     if (ct && !strcmp("application/x-pkcs7-mime", ct)) {
         /* this looks like a root cert and we do not want those in our chain */
         goto out; 
@@ -397,6 +398,7 @@ static apr_status_t on_add_chain(md_acme_t *acme, const md_http_response_t *res,
     
     (void)acme;
     ct = apr_table_get(res->headers, "Content-Type");
+    ct = md_util_parse_ct(res->req->pool, ct);
     if (ct && !strcmp("application/x-pkcs7-mime", ct)) {
         /* root cert most likely, end it here */
         return APR_SUCCESS;

--- a/src/md_acme_drive.c
+++ b/src/md_acme_drive.c
@@ -590,7 +590,7 @@ static apr_status_t acme_driver_init(md_proto_driver_t *d, md_result_t *result)
                              dis_http? " The http: challenge 'http-01' is disabled because the server seems not reachable on public port 80." : "",
                              dis_https? " The https: challenge 'tls-alpn-01' is disabled because the server seems not reachable on public port 443." : "",
                              dis_alpn_acme? " The https: challenge 'tls-alpn-01' is disabled because the Protocols configuration does not include the 'acme-tls/1' protocol." : "",
-                             dis_dns? "The DNS challenge 'dns-01' is disabled because the directive 'MDChallengeDns01' is not configured." : ""
+                             dis_dns? " The DNS challenge 'dns-01' is disabled because the directive 'MDChallengeDns01' is not configured." : ""
                              );
             goto leave;
         }

--- a/src/md_cmd_main.c
+++ b/src/md_cmd_main.c
@@ -41,18 +41,6 @@
 #include "md_cmd_store.h"
 #include "md_curl.h"
 
-/* Called by md_curl to get the trusted CA paths.
- */
-static const char *cafile = NULL, *capath = NULL;
-
-#if 0
-void md_config_get_trusted( const char **certfile, const char **certpath )
-{
-    if( *certfile ) *certfile = cafile;
-    if( *certpath ) *certpath = capath;
-}
-#endif
-
 /**************************************************************************************************/
 /* command infrastructure */
 
@@ -375,12 +363,6 @@ static apr_status_t main_opts(md_cmd_ctx *ctx, int option, const char *optarg)
         case 't':
             ctx->tos = optarg;
             break;
-        case 'T':
-            cafile = optarg;
-            break;
-        case 'P':
-            capath = optarg;
-            break;
         default:
             return APR_EINVAL;
     }
@@ -405,8 +387,6 @@ static apr_getopt_option_t MainOptions [] = {
     { "proxy",   'p', 1, "use the HTTP proxy url"},
     { "quiet",   'q', 0, "produce less output"},
     { "terms",   't', 1, "you agree to the terms of services (url)" },
-    { "trust",   'T', 1, "file containing certificates of CAs to trust (filename)" },
-    { "trustdir",'P', 1, "hashed directory containing certificates of CAs to trust (directory)" },
     { "verbose", 'v', 0, "produce more output" },
     { "version", 'V', 0, "print version" },
     { NULL,       0,  0, NULL }

--- a/src/md_crypt.c
+++ b/src/md_crypt.c
@@ -1380,6 +1380,7 @@ apr_status_t md_cert_read_http(md_cert_t **pcert, apr_pool_t *p,
     apr_status_t rv;
     
     ct = apr_table_get(res->headers, "Content-Type");
+    ct = md_util_parse_ct(res->req->pool, ct);
     if (!res->body || !ct || strcmp("application/pkix-cert", ct)) {
         rv = APR_ENOENT;
         goto out;
@@ -1431,7 +1432,8 @@ apr_status_t md_cert_chain_read_http(struct apr_array_header_t *chain,
         rv = APR_ENOENT;
         goto out;
     }
-    else if (!strcmp("application/pem-certificate-chain", ct)) {
+    ct = md_util_parse_ct(res->req->pool, ct);
+    if (!strcmp("application/pem-certificate-chain", ct)) {
         if (APR_SUCCESS == (rv = apr_brigade_pflatten(res->body, &data, &data_len, res->req->pool))) {
             int added = 0;
             md_cert_t *cert;

--- a/src/md_json.c
+++ b/src/md_json.c
@@ -1182,9 +1182,13 @@ apr_status_t md_json_readf(md_json_t **pjson, apr_pool_t *p, const char *fpath)
 apr_status_t md_json_read_http(md_json_t **pjson, apr_pool_t *pool, const md_http_response_t *res)
 {
     apr_status_t rv = APR_ENOENT;
-    const char *ctype = apr_table_get(res->headers, "content-type");
+    const char *ctype = apr_table_get(res->headers, "content-type"), *p;
+
+    *pjson = NULL;
     ctype = md_util_parse_ct(res->req->pool, ctype);
-    if (ctype && res->body && (strstr(ctype, "/json") || strstr(ctype, "+json"))) {
+    p = ctype + strlen(ctype) +1;
+    if (ctype && res->body && (!strcmp(p - sizeof("/json"), "/json") ||
+                               !strcmp(p - sizeof("+json"), "+json"))) {
         rv = md_json_readb(pjson, pool, res->body);
     }
     return rv;

--- a/src/md_json.c
+++ b/src/md_json.c
@@ -1183,6 +1183,7 @@ apr_status_t md_json_read_http(md_json_t **pjson, apr_pool_t *pool, const md_htt
 {
     apr_status_t rv = APR_ENOENT;
     const char *ctype = apr_table_get(res->headers, "content-type");
+    ctype = md_util_parse_ct(res->req->pool, ctype);
     if (ctype && res->body && (strstr(ctype, "/json") || strstr(ctype, "+json"))) {
         rv = md_json_readb(pjson, pool, res->body);
     }

--- a/src/md_util.c
+++ b/src/md_util.c
@@ -1515,3 +1515,23 @@ const char *md_link_find_relation(const apr_table_t *headers,
     return ctx.url;
 }
 
+const char *md_util_parse_ct(apr_pool_t *pool, const char *cth)
+{
+    char       *type;
+    const char *p;
+    apr_size_t  hlen;
+
+    if (!cth) return NULL;
+
+    for( p = cth; *p && *p != ' ' && *p != ';'; ++p)
+        ;
+    hlen = (apr_size_t)(p - cth);
+    type = apr_pcalloc( pool, hlen + 1 );
+    assert(type);
+    memcpy(type, cth, hlen);
+    type[hlen] = '\0';
+
+    return type;
+    /* Could parse and return parameters here, but we don't need any at present.
+     */
+}

--- a/src/md_util.h
+++ b/src/md_util.h
@@ -213,6 +213,7 @@ apr_status_t md_util_abs_http_uri_check(apr_pool_t *p, const char *uri, const ch
 const char *md_link_find_relation(const struct apr_table_t *headers, 
                                   apr_pool_t *pool, const char *relation);
 
+const char *md_util_parse_ct(apr_pool_t *pool, const char *cth);
 /**************************************************************************************************/
 /* retry logic */
 

--- a/src/mod_md_status.c
+++ b/src/mod_md_status.c
@@ -340,7 +340,7 @@ static void print_job_summary(apr_bucket_brigade *bb, md_json_t *mdj, const char
         return;
     }
     
-    finished = (int)md_json_getl(mdj, key, MD_KEY_FINISHED, NULL);
+    finished = md_json_getb(mdj, key, MD_KEY_FINISHED, NULL);
     errors = (int)md_json_getl(mdj, key, MD_KEY_ERRORS, NULL);
     rv = (apr_status_t)md_json_getl(mdj, key, MD_KEY_LAST, MD_KEY_STATUS, NULL);
     


### PR DESCRIPTION
This change to `a2md` was cherry-picked from another branch.  It relies on support elsewhere in the codebase.

I thought I'd previously backported that support - but I haven't.  It's not worth doing at this point.

@icing's patch disabled the function, but left the switches and documentation. 

This completely reverts the change to `a2md` for master.  It will return when we merge the other branch.

Sorry for the confusion.
