### PR TITLE
mod_md: tolerate missing revokeCert or keyChange resource

### DIFF
--- a/src/md_acme.c
+++ b/src/md_acme.c
@@ -711,8 +711,15 @@ static apr_status_t update_directory(const md_http_response_t *res, void *data)
         acme->api.v2.revoke_cert = md_json_dups(acme->p, json, "revokeCert", NULL);
         acme->api.v2.key_change = md_json_dups(acme->p, json, "keyChange", NULL);
         acme->api.v2.new_nonce = md_json_dups(acme->p, json, "newNonce", NULL);
-        if (acme->api.v2.new_account && acme->api.v2.new_order 
-            && acme->api.v2.revoke_cert && acme->api.v2.key_change
+        /* RFC 8555 only requires "directory" and "newNonce" resources.
+         * mod_md uses "newAccount" and "newOrder" so check for them.
+         * But mod_md does not use the "revokeCert" or "keyChange"
+         * resources, so tolerate the absense of those keys.  In the
+         * future if mod_md implements revocation or key rollover then
+         * the use of those features should be predicated on the
+         * server's advertised capabilities. */
+        if (acme->api.v2.new_account
+            && acme->api.v2.new_order
             && acme->api.v2.new_nonce) {
             acme->version = MD_ACME_VERSION_2;
         }


### PR DESCRIPTION
RFC 8555 §7.1 states:

  The server MUST provide "directory" and "newNonce" resources.

But RFC 8555 makes no explicit statement anywhere whether other
resources are, or are not, required (with the exception of
"newAuthz" which is optional).

Therefore it is possible that some ACME server implementations may
omit some resources; in particular those that are not an essential
part of the "order" workflow.  Indeed, I am working with one such
server implementation, which does not at this time implement
"keyChange".  mod_md is summarily refusing to interact with this
server because it is zealously checking that a certain set of
resources are defined in the directory object - despite some of
those resources never being used anywhere.

Update the check to require only "newNonce", "newAccount" and
"newOrder".  Omit from the check and therefore tolerate the absense
of resources which are never used: "revokeCert" and "keyChange".