### PR TITLE
Don't hard-code -Werror.

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -22,7 +22,7 @@ lib_LTLIBRARIES    = libmd.la mod_md.la
 # static lib, linked by module and a2md
 #---------------------------------------------------------------------------------------------------
 
-libmd_la_CPPFLAGS = -fPIC -g -std=c99 -D_GNU_SOURCE -Werror @WERROR_CFLAGS@
+libmd_la_CPPFLAGS = -fPIC -g -std=c99 -D_GNU_SOURCE @WERROR_CFLAGS@
 libmd_la_LDFLAGS  = @LDFLAGS@ -static -ljansson -lcurl -lssl -lcrypto
 
 A2LIB_OBJECTS = \
@@ -81,7 +81,7 @@ libmd_la_SOURCES = $(A2LIB_HFILES) $(A2LIB_OBJECTS)
 # mod_md for httpd
 #---------------------------------------------------------------------------------------------------
 
-mod_md_la_CPPFLAGS = -g -I../src -std=c99 -D_GNU_SOURCE -Werror @WERROR_CFLAGS@
+mod_md_la_CPPFLAGS = -g -I../src -std=c99 -D_GNU_SOURCE @WERROR_CFLAGS@
 mod_md_la_LDFLAGS  = -module -L../src -lmd -ljansson -lcurl -lssl -lcrypto -export-symbols-regex md_module
 
 
@@ -114,7 +114,7 @@ all: mod_md.la
 
 bin_PROGRAMS       = a2md
 
-a2md_CFLAGS  = -g -I../src -std=c99 -D_GNU_SOURCE -Werror @WERROR_CFLAGS@
+a2md_CFLAGS  = -g -I../src -std=c99 -D_GNU_SOURCE @WERROR_CFLAGS@
 a2md_LDFLAGS = @LDFLAGS@ -L../src -lmd -l@LIB_APR@ -l@LIB_APRUTIL@ -ljansson -lcurl -lssl -lcrypto
 
 A2MD_OBJECTS = \

--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -41,7 +41,7 @@ check_PROGRAMS = unit/main
 unit_main_SOURCES = unit/main.c unit/test_md_json.c unit/test_md_util.c unit/test_common.h
 unit_main_LDADD   = $(top_builddir)/src/libmd.la
 
-unit_main_CFLAGS  = $(CHECK_CFLAGS) -Werror -I$(top_srcdir)/src
+unit_main_CFLAGS  = $(CHECK_CFLAGS) -I$(top_srcdir)/src
 unit_main_LDADD  += $(CHECK_LIBS) -l$(LIB_APR) -l$(LIB_APRUTIL)
 
 unit_tests: $(TESTS)


### PR DESCRIPTION
Not sure if I am missing something here but use of `-Werror` is hard-coded into the `Makefile.am` as well as being an opt-in configure-switch, is that deliberate?  