### PR TITLE
fix build with LibreSSL

### DIFF
--- a/src/md_crypt.c
+++ b/src/md_crypt.c
@@ -795,7 +795,7 @@ static apr_status_t gen_ec(md_pkey_t **ppkey, apr_pool_t *p, const char *curve)
         curve_nid = NID_X9_62_prime192v1;
     }
 #endif
-#ifdef NID_X25519
+#if defined(NID_X25519) && !defined(LIBRESSL_VERSION_NUMBER)
     if (NID_undef == curve_nid && !apr_strnatcasecmp("X25519", curve)) {
         curve_nid = NID_X25519;
     }
@@ -812,7 +812,7 @@ static apr_status_t gen_ec(md_pkey_t **ppkey, apr_pool_t *p, const char *curve)
     *ppkey = make_pkey(p);
     switch (curve_nid) {
 
-#ifdef NID_X25519
+#if defined(NID_X25519) && !defined(LIBRESSL_VERSION_NUMBER)
     case NID_X25519:
         /* no parameters */
         if (NULL == (ctx = EVP_PKEY_CTX_new_id(EVP_PKEY_X25519, NULL))
@@ -826,7 +826,7 @@ static apr_status_t gen_ec(md_pkey_t **ppkey, apr_pool_t *p, const char *curve)
         break;
 #endif
 
-#ifdef NID_X448
+#if defined(NID_X448) && !defined(LIBRESSL_VERSION_NUMBER)
     case NID_X448:
         /* no parameters */
         if (NULL == (ctx = EVP_PKEY_CTX_new_id(EVP_PKEY_X448, NULL))


### PR DESCRIPTION
LibreSSL does not expose X25519 via EVP and has no X448 support.
patch by Theo Buehler