### PR TITLE
Check that the private key and the certificate match

### DIFF
--- a/src/md_acme_drive.c
+++ b/src/md_acme_drive.c
@@ -922,6 +922,10 @@ static apr_status_t acme_preload(md_proto_driver_t *d, md_store_group_t load_gro
             md_result_printf(result, rv, "no certificate in staged credentials #%d", i);
             goto leave;
         }
+        if (APR_SUCCESS != (rv = md_check_cert_and_pkey(creds->chain, creds->pkey))) {
+            md_result_printf(result, rv, "certificate and private key do not match in staged credentials #%d", i);
+            goto leave;
+        }
         APR_ARRAY_PUSH(all_creds, md_credentials_t*) = creds;
     }
     

--- a/src/md_crypt.c
+++ b/src/md_crypt.c
@@ -2016,7 +2016,13 @@ cleanup:
 
 apr_status_t md_check_cert_and_pkey(struct apr_array_header_t *certs, md_pkey_t *pkey)
 {
-    const md_cert_t *cert = APR_ARRAY_IDX(certs, 0, const md_cert_t*);
+    const md_cert_t *cert;
+
+    if (certs->nelts == 0) {
+        return APR_ENOENT;
+    }
+
+    cert = APR_ARRAY_IDX(certs, 0, const md_cert_t*);
 
     if (1 != X509_check_private_key(cert->x509, pkey->pkey)) {
         return APR_EGENERAL;

--- a/src/md_crypt.c
+++ b/src/md_crypt.c
@@ -2014,3 +2014,13 @@ cleanup:
     return rv;
 }
 
+apr_status_t md_check_cert_and_pkey(struct apr_array_header_t *certs, md_pkey_t *pkey)
+{
+    const md_cert_t *cert = APR_ARRAY_IDX(certs, 0, const md_cert_t*);
+
+    if (1 != X509_check_private_key(cert->x509, pkey->pkey)) {
+        return APR_EGENERAL;
+    }
+
+    return APR_SUCCESS;
+}

--- a/src/md_crypt.h
+++ b/src/md_crypt.h
@@ -218,6 +218,9 @@ apr_status_t md_cert_get_ct_scts(apr_array_header_t *scts, apr_pool_t *p, const 
 
 apr_status_t md_cert_get_ocsp_responder_url(const char **purl, apr_pool_t *p, const md_cert_t *cert);
 
+apr_status_t md_check_cert_and_pkey(struct apr_array_header_t *certs, md_pkey_t *pkey);
+
+
 /**************************************************************************************************/
 /* X509 certificate transparency */
 


### PR DESCRIPTION
This extra check is only needed to prevent errors on the CA's side, or in
special deployments (e.g. in a cluster that has multiple instances of httpd
and mod_md running, and multiple instances try to renew certificates at the
same time).