### PR TITLE
also abort in tls and dns challenges if the script exits with != 0

### DIFF
--- a/src/md_acme_authz.c
+++ b/src/md_acme_authz.c
@@ -393,7 +393,13 @@ static apr_status_t cha_tls_alpn_01_setup(md_acme_authz_cha_t *cha, md_acme_auth
         /* Raise event that challenge data has been set up before we tell the
            ACME server. Clusters might want to distribute it. */
         event = apr_psprintf(p, "challenge-setup:%s:%s", MD_AUTHZ_TYPE_TLSALPN01, authz->domain);
-        md_result_holler(result, event, p);
+        rv = md_result_raise(result, event, p);
+        if (APR_SUCCESS != rv) {
+            md_log_perror(MD_LOG_MARK, MD_LOG_DEBUG, rv, p,
+                          "%s: event '%s' failed. aborting challenge setup",
+                          authz->domain, event);
+            goto out;
+        }
         /* challenge is setup or was changed from previous data, tell ACME server
          * so it may (re)try verification */        
         authz_req_ctx_init(&ctx, acme, NULL, authz, p);
@@ -463,7 +469,13 @@ static apr_status_t cha_dns_01_setup(md_acme_authz_cha_t *cha, md_acme_authz_t *
     /* Raise event that challenge data has been set up before we tell the
        ACME server. Clusters might want to distribute it. */
     event = apr_psprintf(p, "challenge-setup:%s:%s", MD_AUTHZ_TYPE_DNS01, authz->domain);
-    md_result_holler(result, event, p);
+    rv = md_result_raise(result, event, p);
+    if (APR_SUCCESS != rv) {
+        md_log_perror(MD_LOG_MARK, MD_LOG_DEBUG, rv, p,
+                      "%s: event '%s' failed. aborting challenge setup",
+                      authz->domain, event);
+        goto out;
+    }
     /* challenge is setup, tell ACME server so it may (re)try verification */
     md_log_perror(MD_LOG_MARK, MD_LOG_DEBUG, rv, p, "%s: dns-01 setup succeeded for %s",
        mdomain, authz->domain);


### PR DESCRIPTION
[this change](https://github.com/icing/mod_md/commit/5f6aa7f16f5f30c98b6c96a8d45c29ca549fcefe) adds the desired behavior, as discussed [here](https://github.com/icing/mod_md/issues/237) 

but only for http challenge type. this pull request adds the same behavior to tls and dns challenges. 
unfortunately i don't have the local test environment setup so **tests are missing in this PR**