### PR TITLE
Full output for server-status auto mode

### DIFF
--- a/src/mod_md_status.c
+++ b/src/mod_md_status.c
@@ -407,7 +407,7 @@ static void print_job_summary(status_ctx *ctx, md_json_t *mdj, const char *key,
     if (t > apr_time_now() && !finished) {
         print_time(ctx, "\nNext run", t);
     }
-    else if (!strlen(line)) {
+    else if (line[0] != '\0') {
         if (HTML_STATUS(ctx)) {
             apr_brigade_puts(bb, NULL, NULL, "\nOngoing...");
         }

--- a/src/mod_md_status.c
+++ b/src/mod_md_status.c
@@ -486,7 +486,7 @@ static const status_info status_infos[] = {
     { "Valid", MD_KEY_CERT, si_val_cert_valid_time },
     { "CA", MD_KEY_CA, si_val_ca_url },
     { "Stapling", MD_KEY_STAPLING, si_val_stapling },
-    { "Check@", MD_KEY_SHA256_FINGERPRINT, si_val_remote_check },
+    { "CheckAt", MD_KEY_SHA256_FINGERPRINT, si_val_remote_check },
     { "Activity",  MD_KEY_NOTIFIED, si_val_activity },
 };
 
@@ -585,9 +585,9 @@ static void si_val_ocsp_activity(status_ctx *ctx, md_json_t *mdj, const status_i
 
 static const status_info ocsp_status_infos[] = {
     { "Domain", MD_KEY_DOMAIN, NULL },
-    { "Certificate ID", MD_KEY_ID, NULL },
-    { "OCSP Status", MD_KEY_STATUS, NULL },
-    { "Stapling Valid", MD_KEY_VALID, si_val_valid_time },
+    { "CertificateID", MD_KEY_ID, NULL },
+    { "OCSPStatus", MD_KEY_STATUS, NULL },
+    { "StaplingValid", MD_KEY_VALID, si_val_valid_time },
     { "Responder", MD_KEY_URL, si_val_url },
     { "Activity",  MD_KEY_NOTIFIED, si_val_ocsp_activity },
 };


### PR DESCRIPTION
Implement full auto status ("key: value" type status output). Especially not only status summary counts for certificates and OCSP stapling but also lists. Auto status format is similar to what was used for mod_proxy_balancer.
Certificate details were tested, OCSP stapling output was not yet tested.
Since there were quite a few "if-else" introduced, a "diff -w" or "git diff -b" helps reduce diff clutter.
The change was split into several smaller commits to make it easier to review.