### PR TITLE
Tailscale Support

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -260,6 +260,9 @@ AC_SUBST(MODULE_SRC)
 ACME_DEF_URL=https://acme-v02.api.letsencrypt.org/directory
 AC_SUBST(ACME_DEF_URL)
 
+TAILSCALE_DEF_URL="file://localhost/var/run/tailscale/tailscaled.sock"
+AC_SUBST(TAILSCALE_DEF_URL)
+
 # it must be configurable without an ACME test server installed
 ACME_TEST_TYPE="none"
 ACME_TEST_URL="none"

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -47,6 +47,7 @@ A2LIB_OBJECTS = \
     md_status.c \
     md_store.c \
     md_store_fs.c \
+    md_tailscale.c \
     md_time.c \
     md_util.c
 
@@ -70,6 +71,7 @@ A2LIB_HFILES = \
     md_status.h \
     md_store.h \
     md_store_fs.h \
+    md_tailscale.h \
     md_time.h \
     md_util.h \
     md.h

--- a/src/md_acme_drive.c
+++ b/src/md_acme_drive.c
@@ -1036,9 +1036,19 @@ static apr_status_t acme_driver_preload(md_proto_driver_t *d,
     return rv;
 }
 
+static apr_status_t acme_complete_md(md_t *md, apr_pool_t *p)
+{
+    (void)p;
+    if (!md->ca_url) {
+        md->ca_url = MD_ACME_DEF_URL;
+    }
+    return APR_SUCCESS;
+}
+
 static md_proto_t ACME_PROTO = {
     MD_PROTO_ACME, acme_driver_init, acme_driver_renew, 
-    acme_driver_preload_init, acme_driver_preload
+    acme_driver_preload_init, acme_driver_preload,
+    acme_complete_md,
 };
  
 apr_status_t md_acme_protos_add(apr_hash_t *protos, apr_pool_t *p)

--- a/src/md_core.c
+++ b/src/md_core.c
@@ -427,7 +427,7 @@ apr_status_t md_get_ca_url_from_name(const char **purl, apr_pool_t *p, const cha
         }
     }
     *purl = name;
-    rv = md_util_abs_http_uri_check(p, name, &err);
+    rv = md_util_abs_uri_check(p, name, &err);
     if (APR_SUCCESS != rv) {
         apr_array_header_t *names;
 

--- a/src/md_crypt.h
+++ b/src/md_crypt.h
@@ -117,6 +117,12 @@ void *md_pkey_get_EVP_PKEY(struct md_pkey_t *pkey);
 apr_status_t md_crypt_hmac64(const char **pmac64, const struct md_data_t *hmac_key,
                              apr_pool_t *p, const char *d, size_t dlen);
 
+/**
+ * Read a private key from a http response.
+ */
+apr_status_t md_pkey_read_http(md_pkey_t **ppkey, apr_pool_t *pool,
+                               const struct md_http_response_t *res);
+
 /**************************************************************************************************/
 /* X509 certificates */
 
@@ -178,6 +184,11 @@ int md_cert_must_staple(const md_cert_t *cert);
 apr_time_t md_cert_get_not_after(const md_cert_t *cert);
 apr_time_t md_cert_get_not_before(const md_cert_t *cert);
 struct md_timeperiod_t md_cert_get_valid(const md_cert_t *cert);
+
+/**
+ * Return != 0 iff the hash values of the certificates are equal.
+ */
+int md_certs_are_equal(const md_cert_t *a, const md_cert_t *b);
 
 apr_status_t md_cert_get_issuers_uri(const char **puri, const md_cert_t *cert, apr_pool_t *p);
 apr_status_t md_cert_get_alt_names(apr_array_header_t **pnames, const md_cert_t *cert, apr_pool_t *p);

--- a/src/md_curl.c
+++ b/src/md_curl.c
@@ -301,6 +301,9 @@ static apr_status_t internals_setup(md_http_request_t *req)
     if (req->ca_file) {
         curl_easy_setopt(curl, CURLOPT_CAINFO, req->ca_file);
     }
+    if (req->unix_socket_path) {
+        curl_easy_setopt(curl, CURLOPT_UNIX_SOCKET_PATH, req->unix_socket_path);
+    }
 
     if (req->body_len >= 0) {
         /* set the Content-Length */

--- a/src/md_http.c
+++ b/src/md_http.c
@@ -33,6 +33,7 @@ struct md_http_t {
     void *impl_data;         /* to be used by the implementation */
     const char *user_agent;
     const char *proxy_url;
+    const char *unix_socket_path;
     md_http_timeouts_t timeout;
     const char *ca_file;
 };
@@ -143,6 +144,11 @@ void md_http_set_ca_file(md_http_t *http, const char *ca_file)
     http->ca_file = ca_file;
 }
 
+void md_http_set_unix_socket_path(md_http_t *http, const char *path)
+{
+    http->unix_socket_path = path;
+}
+
 static apr_status_t req_set_body(md_http_request_t *req, const char *content_type,
                                  apr_bucket_brigade *body, apr_off_t body_len,
                                  int detect_len)
@@ -211,6 +217,7 @@ static apr_status_t req_create(md_http_request_t **preq, md_http_t *http,
     req->proxy_url = http->proxy_url;
     req->timeout = http->timeout;
     req->ca_file = http->ca_file;
+    req->unix_socket_path = http->unix_socket_path;
     *preq = req;
     return rv;
 }

--- a/src/md_http.h
+++ b/src/md_http.h
@@ -65,6 +65,7 @@ struct md_http_request_t {
     const char *user_agent;
     const char *proxy_url;
     const char *ca_file;
+    const char *unix_socket_path;
     apr_table_t *headers;
     struct apr_bucket_brigade *body;
     apr_off_t body_len;
@@ -116,6 +117,12 @@ void md_http_set_stalling(md_http_request_t *req, long bytes_per_sec, apr_time_t
  * certificate store will be used.
  */
 void md_http_set_ca_file(md_http_t *http, const char *ca_file);
+
+/**
+ * Set the path of a unix domain socket for use instead of TCP
+ * in a connection. Disable by providing NULL as path.
+ */
+void md_http_set_unix_socket_path(md_http_t *http, const char *path);
 
 /**
  * Perform the request. Then this function returns, the request and

--- a/src/md_reg.h
+++ b/src/md_reg.h
@@ -220,6 +220,7 @@ typedef apr_status_t md_proto_renew_cb(md_proto_driver_t *driver, struct md_resu
 typedef apr_status_t md_proto_init_preload_cb(md_proto_driver_t *driver, struct md_result_t *result);
 typedef apr_status_t md_proto_preload_cb(md_proto_driver_t *driver, 
                                          md_store_group_t group, struct md_result_t *result);
+typedef apr_status_t md_proto_complete_md_cb(md_t *md, apr_pool_t *p);
 
 struct md_proto_t {
     const char *protocol;
@@ -227,6 +228,7 @@ struct md_proto_t {
     md_proto_renew_cb *renew;
     md_proto_init_preload_cb *init_preload;
     md_proto_preload_cb *preload;
+    md_proto_complete_md_cb *complete_md;
 };
 
 /**

--- a/src/md_tailscale.c
+++ b/src/md_tailscale.c
@@ -1,0 +1,296 @@
+/* Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <assert.h>
+#include <stdlib.h>
+
+#include <apr_lib.h>
+#include <apr_strings.h>
+#include <apr_hash.h>
+#include <apr_uri.h>
+
+#include "md.h"
+#include "md_crypt.h"
+#include "md_json.h"
+#include "md_http.h"
+#include "md_log.h"
+#include "md_result.h"
+#include "md_reg.h"
+#include "md_store.h"
+#include "md_util.h"
+
+#include "md_tailscale.h"
+
+typedef struct {
+    apr_pool_t *pool;
+    md_proto_driver_t *driver;
+    const char *unix_socket_path;
+    apr_array_header_t *chain;
+    md_pkey_t *pkey;
+} ts_ctx_t;
+
+static apr_status_t ts_init(md_proto_driver_t *d, md_result_t *result)
+{
+    ts_ctx_t *ts_ctx;
+
+    md_result_set(result, APR_SUCCESS, NULL);
+    ts_ctx = apr_pcalloc(d->p, sizeof(*ts_ctx));
+    ts_ctx->pool = d->p;
+    ts_ctx->driver = d;
+    ts_ctx->unix_socket_path = "/var/run/tailscale/tailscaled.sock";
+    d->baton = ts_ctx;
+
+    return APR_SUCCESS;
+}
+
+static apr_status_t ts_preload_init(md_proto_driver_t *d, md_result_t *result)
+{
+    return ts_init(d, result);
+}
+
+static apr_status_t ts_preload(md_proto_driver_t *d,
+                               md_store_group_t load_group, md_result_t *result)
+{
+    apr_status_t rv;
+    md_t *md;
+    md_credentials_t *creds;
+    md_pkey_spec_t *pkspec;
+    apr_array_header_t *all_creds;
+    const char *name;
+    int i;
+
+    name = d->md->name;
+    md_log_perror(MD_LOG_MARK, MD_LOG_DEBUG, 0, d->p, "%s: preload start", name);
+    /* Load data from MD_SG_STAGING and save it into "load_group".
+     */
+    if (APR_SUCCESS != (rv = md_load(d->store, MD_SG_STAGING, name, &md, d->p))) {
+        md_result_set(result, rv, "loading staged md.json");
+        goto leave;
+    }
+
+     /* tailscale generates one cert+key with key specification being whatever
+      * it chooses. Use the NULL spec here.
+      */
+    all_creds = apr_array_make(d->p, 5, sizeof(md_credentials_t*));
+    pkspec = NULL;
+    if (APR_SUCCESS != (rv = md_creds_load(d->store, MD_SG_STAGING, name, pkspec, &creds, d->p))) {
+        md_result_printf(result, rv, "loading staged credentials");
+        goto leave;
+    }
+    if (!creds->chain) {
+        rv = APR_ENOENT;
+        md_result_printf(result, rv, "no certificate in staged credentials");
+        goto leave;
+    }
+    if (APR_SUCCESS != (rv = md_check_cert_and_pkey(creds->chain, creds->pkey))) {
+        md_result_printf(result, rv, "certificate and private key do not match in staged credentials");
+        goto leave;
+    }
+    APR_ARRAY_PUSH(all_creds, md_credentials_t*) = creds;
+
+    md_result_activity_setn(result, "purging store tmp space");
+    rv = md_store_purge(d->store, d->p, load_group, name);
+    if (APR_SUCCESS != rv) {
+        md_result_set(result, rv, NULL);
+        goto leave;
+    }
+
+    md_result_activity_setn(result, "saving staged md/privkey/pubcert");
+    if (APR_SUCCESS != (rv = md_save(d->store, d->p, load_group, md, 1))) {
+        md_result_set(result, rv, "writing md.json");
+        goto leave;
+    }
+
+    for (i = 0; i < all_creds->nelts; ++i) {
+        creds = APR_ARRAY_IDX(all_creds, i, md_credentials_t*);
+        if (APR_SUCCESS != (rv = md_creds_save(d->store, d->p, load_group, name, creds, 1))) {
+            md_result_printf(result, rv, "writing credentials #%d", i);
+            goto leave;
+        }
+    }
+
+    md_result_set(result, APR_SUCCESS, "saved staged data successfully");
+
+leave:
+    md_result_log(result, MD_LOG_DEBUG);
+    return rv;
+}
+
+static apr_status_t rv_of_response(const md_http_response_t *res)
+{
+    switch (res->status) {
+        case 200:
+            return APR_SUCCESS;
+        case 400:
+            return APR_EINVAL;
+        case 401: /* sectigo returns this instead of 403 */
+        case 403:
+            return APR_EACCES;
+        case 404:
+            return APR_ENOENT;
+        default:
+            return APR_EGENERAL;
+    }
+    return APR_SUCCESS;
+}
+
+static apr_status_t on_get_cert(const md_http_response_t *res, void *baton)
+{
+    ts_ctx_t *ts_ctx = baton;
+    apr_status_t rv;
+
+    rv = rv_of_response(res);
+    if (APR_SUCCESS != rv) goto leave;
+    apr_array_clear(ts_ctx->chain);
+    rv = md_cert_chain_read_http(ts_ctx->chain, ts_ctx->pool, res);
+    if (APR_SUCCESS != rv) goto leave;
+
+leave:
+    return rv;
+}
+
+static apr_status_t on_get_key(const md_http_response_t *res, void *baton)
+{
+    ts_ctx_t *ts_ctx = baton;
+    apr_status_t rv;
+
+    rv = rv_of_response(res);
+    if (APR_SUCCESS != rv) goto leave;
+    rv = md_pkey_read_http(&ts_ctx->pkey, ts_ctx->pool, res);
+    if (APR_SUCCESS != rv) goto leave;
+
+leave:
+    return rv;
+}
+
+static apr_status_t ts_renew(md_proto_driver_t *d, md_result_t *result)
+{
+    const char *name, *domain, *url;
+    apr_status_t rv = APR_ENOENT;
+    ts_ctx_t *ts_ctx = d->baton;
+    md_http_t *http;
+    const md_pubcert_t *pubcert;
+    md_cert_t *old_cert, *new_cert;
+
+    /* "renewing" the certificate from tailscale. Since tailscale has its
+     * own ideas on when to do this, we can only inspect the certificate
+     * it gives us and see if it is different from the current one we have.
+     * (if we have any. first time, lacking a cert, any it gives us is
+     *  considered as 'renewed'.)
+     */
+    name = d->md->name;
+    md_log_perror(MD_LOG_MARK, MD_LOG_DEBUG, 0, d->p, "%s: renewing cert", name);
+
+    if (!ts_ctx->unix_socket_path) {
+        rv = APR_ENOTIMPL;
+        md_result_set(result, rv, "only unix sockets are supported for tailscale connections");
+        goto leave;
+    }
+
+    rv = md_util_is_unix_socket(ts_ctx->unix_socket_path, d->p);
+    if (APR_SUCCESS != rv) {
+        md_result_printf(result, rv, "tailscale socket not available, may not be up: %s",
+                         ts_ctx->unix_socket_path);
+        goto leave;
+    }
+
+    rv = md_http_create(&http, d->p,
+                        apr_psprintf(d->p, "Apache mod_md/%s", MOD_MD_VERSION),
+                        NULL);
+    if (APR_SUCCESS != rv) {
+        md_result_set(result, rv, "creating http context");
+        goto leave;
+    }
+    md_http_set_unix_socket_path(http, ts_ctx->unix_socket_path);
+
+    domain = (d->md->domains->nelts > 0)?
+              APR_ARRAY_IDX(d->md->domains, 0, const char*) : NULL;
+    if (!domain) {
+        rv = APR_EINVAL;
+        md_result_set(result, rv, "no domain names available");
+    }
+
+    url = apr_psprintf(d->p, "http://localhost/localapi/v0/cert/%s?type=crt",
+                       domain);
+    rv = md_http_GET_perform(http, url, NULL, on_get_cert, ts_ctx);
+    if (APR_SUCCESS != rv) {
+        md_result_set(result, rv, "retrieving certificate from tailscale");
+        goto leave;
+    }
+    if (ts_ctx->chain->nelts <= 0) {
+        rv = APR_ENOENT;
+        md_result_set(result, rv, "tailscale returned no certificates");
+        goto leave;
+    }
+
+    /* Got the key and the chain, is it new? */
+    rv = md_reg_get_pubcert(&pubcert, d->reg,d->md, 0, d->p);
+    if (APR_SUCCESS == rv) {
+        old_cert = APR_ARRAY_IDX(pubcert->certs, 0, md_cert_t*);
+        new_cert = APR_ARRAY_IDX(ts_ctx->chain, 0, md_cert_t*);
+        if (md_certs_are_equal(old_cert, new_cert)) {
+            /* tailscale has not renewed the certificate, yet */
+            rv = APR_ENOENT;
+            md_result_set(result, rv, "tailscale has not renewed the certificate yet");
+            goto leave;
+        }
+    }
+
+    /* We have a new certificate (or had none before).
+     * Get the key and store both in STAGING.
+     */
+    url = apr_psprintf(d->p, "http://localhost/localapi/v0/cert/%s?type=key",
+                       domain);
+    rv = md_http_GET_perform(http, url, NULL, on_get_key, ts_ctx);
+    if (APR_SUCCESS != rv) {
+        md_result_set(result, rv, "retrieving key from tailscale");
+        goto leave;
+    }
+
+    rv = md_pkey_save(d->store, d->p, MD_SG_STAGING, name, NULL, ts_ctx->pkey, 1);
+    if (APR_SUCCESS != rv) {
+        md_result_set(result, rv, "saving private key");
+        goto leave;
+    }
+
+    rv = md_pubcert_save(d->store, d->p, MD_SG_STAGING, name,
+                         NULL, ts_ctx->chain, 1);
+    if (APR_SUCCESS != rv) {
+        md_result_printf(result, rv, "saving new certificate chain.");
+        goto leave;
+    }
+
+    md_result_set(result, APR_SUCCESS,
+        "A new tailscale certificate has been retrieved successfully and can "
+        "be used. A graceful server restart is recommended.");
+
+leave:
+    md_result_log(result, MD_LOG_DEBUG);
+    return rv;
+}
+
+
+static md_proto_t TAILSCALE_PROTO = {
+    MD_PROTO_TAILSCALE, ts_init, ts_renew,
+    ts_preload_init, ts_preload
+};
+
+apr_status_t md_tailscale_protos_add(apr_hash_t *protos, apr_pool_t *p)
+{
+    (void)p;
+    apr_hash_set(protos, MD_PROTO_TAILSCALE, sizeof(MD_PROTO_TAILSCALE)-1, &TAILSCALE_PROTO);
+    return APR_SUCCESS;
+}

--- a/src/md_tailscale.c
+++ b/src/md_tailscale.c
@@ -47,6 +47,7 @@ static apr_status_t ts_init(md_proto_driver_t *d, md_result_t *result)
 {
     ts_ctx_t *ts_ctx;
     apr_uri_t uri;
+    const char *ca_url;
     apr_status_t rv = APR_SUCCESS;
 
     md_result_set(result, APR_SUCCESS, NULL);
@@ -55,10 +56,9 @@ static apr_status_t ts_init(md_proto_driver_t *d, md_result_t *result)
     ts_ctx->driver = d;
     ts_ctx->chain = apr_array_make(d->p, 5, sizeof(md_cert_t *));
 
-    if (!d->md->ca_url) {
-        rv = APR_EINVAL;
-        md_result_set(result, rv, "CA URL missing");
-        goto leave;
+    ca_url = d->md->ca_url;
+    if (!ca_url) {
+        ca_url = MD_TAILSCALE_DEF_URL;
     }
     rv = apr_uri_parse(d->p, d->md->ca_url, &uri);
     if (APR_SUCCESS != rv) {

--- a/src/md_tailscale.c
+++ b/src/md_tailscale.c
@@ -60,21 +60,21 @@ static apr_status_t ts_init(md_proto_driver_t *d, md_result_t *result)
     if (!ca_url) {
         ca_url = MD_TAILSCALE_DEF_URL;
     }
-    rv = apr_uri_parse(d->p, d->md->ca_url, &uri);
+    rv = apr_uri_parse(d->p, ca_url, &uri);
     if (APR_SUCCESS != rv) {
-        md_result_printf(result, rv, "error parsing CA URL `%s`", d->md->ca_url);
+        md_result_printf(result, rv, "error parsing CA URL `%s`", ca_url);
         goto leave;
     }
     if (uri.scheme && uri.scheme[0] && strcmp("file", uri.scheme)) {
         rv = APR_ENOTIMPL;
         md_result_printf(result, rv, "non `file` URLs not supported, CA URL is `%s`",
-                         d->md->ca_url);
+                         ca_url);
         goto leave;
     }
     if (uri.hostname && uri.hostname[0] && strcmp("localhost", uri.hostname)) {
         rv = APR_ENOTIMPL;
         md_result_printf(result, rv, "non `localhost` URLs not supported, CA URL is `%s`",
-                         d->md->ca_url);
+                         ca_url);
         goto leave;
     }
     ts_ctx->unix_socket_path = uri.path;

--- a/src/md_tailscale.h
+++ b/src/md_tailscale.h
@@ -1,0 +1,25 @@
+/* Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef mod_md_md_tailscale_h
+#define mod_md_md_tailscale_h
+
+#define MD_PROTO_TAILSCALE      "tailscale"
+
+apr_status_t md_tailscale_protos_add(struct apr_hash_t *protos, apr_pool_t *p);
+
+#endif /* mod_md_md_tailscale_h */
+

--- a/src/md_util.c
+++ b/src/md_util.c
@@ -398,6 +398,16 @@ apr_status_t md_util_is_file(const char *path, apr_pool_t *pool)
     return rv;
 }
 
+apr_status_t md_util_is_unix_socket(const char *path, apr_pool_t *pool)
+{
+    apr_finfo_t info;
+    apr_status_t rv = apr_stat(&info, path, APR_FINFO_TYPE, pool);
+    if (rv == APR_SUCCESS) {
+        rv = (info.filetype == APR_SOCK)? APR_SUCCESS : APR_EINVAL;
+    }
+    return rv;
+}
+
 int md_file_exists(const char *fname, apr_pool_t *p)
 {
     return (fname && *fname && APR_SUCCESS == md_util_is_file(fname, p));

--- a/src/md_util.h
+++ b/src/md_util.h
@@ -189,6 +189,7 @@ apr_status_t md_util_path_merge(const char **ppath, apr_pool_t *p, ...);
 
 apr_status_t md_util_is_dir(const char *path, apr_pool_t *pool);
 apr_status_t md_util_is_file(const char *path, apr_pool_t *pool);
+apr_status_t md_util_is_unix_socket(const char *path, apr_pool_t *pool);
 int md_file_exists(const char *fname, apr_pool_t *p);
 
 typedef apr_status_t md_util_file_cb(void *baton, struct apr_file_t *f, apr_pool_t *p);

--- a/src/md_version.h
+++ b/src/md_version.h
@@ -37,6 +37,7 @@
  */
 #define MOD_MD_VERSION_NUM 0x02040d
 
-#define MD_ACME_DEF_URL    "https://acme-v02.api.letsencrypt.org/directory"
+#define MD_ACME_DEF_URL         "https://acme-v02.api.letsencrypt.org/directory"
+#define MD_TAILSCALE_DEF_URL    "file://localhost/var/run/tailscale/tailscaled.sock"
 
 #endif /* mod_md_md_version_h */

--- a/src/md_version.h.in
+++ b/src/md_version.h.in
@@ -37,6 +37,7 @@
  */
 #define MOD_MD_VERSION_NUM @PACKAGE_VERSION_NUM@
 
-#define MD_ACME_DEF_URL    "@ACME_DEF_URL@"
+#define MD_ACME_DEF_URL         "@ACME_DEF_URL@"
+#define MD_TAILSCALE_DEF_URL    "@TAILSCALE_DEF_URL@"
 
 #endif /* mod_md_md_version_h */

--- a/src/mod_md_config.c
+++ b/src/mod_md_config.c
@@ -26,6 +26,7 @@
 #include <http_vhost.h>
 
 #include "md.h"
+#include "md_acme.h"
 #include "md_crypt.h"
 #include "md_log.h"
 #include "md_json.h"
@@ -108,7 +109,7 @@ static md_srv_conf_t defconf = {
     &def_warn_window,          /* warn window */
     NULL,                      /* ca url */
     NULL,                      /* ca contact (email) */
-    "ACME",                    /* ca protocol */
+    MD_PROTO_ACME,             /* ca protocol */
     NULL,                      /* ca agreemnent */
     NULL,                      /* ca challenges array */
     NULL,                      /* ca eab kid */

--- a/src/mod_md_status.c
+++ b/src/mod_md_status.c
@@ -352,11 +352,31 @@ static void si_val_cert_valid_time(status_ctx *ctx, md_json_t *mdj, const status
 static void si_val_ca_url(status_ctx *ctx, md_json_t *mdj, const status_info *info)
 {
     md_json_t *jcert;
-    status_info sub = *info;
 
-    sub.key = MD_KEY_URL;
     jcert = md_json_getj(mdj, info->key, NULL);
-    if (jcert) si_val_url(ctx, jcert, &sub);
+    if (jcert) {
+        const char *proto, *s, *url;
+
+        proto = md_json_gets(jcert, MD_KEY_PROTO, NULL);
+        s = url = md_json_gets(jcert, MD_KEY_URL, NULL);
+        if (url) {
+            s = md_get_ca_name_from_url(ctx->p, url);
+        }
+        if ((!s || !s[0]) && (proto && !strcmp(proto, "tailscale"))) {
+            s = "tailscale";
+        }
+        if (HTML_STATUS(ctx)) {
+            apr_brigade_printf(ctx->bb, NULL, NULL, "<a href='%s'>%s</a>",
+                               ap_escape_html2(ctx->p, url, 1),
+                               ap_escape_html2(ctx->p, s, 1));
+        }
+        else {
+            apr_brigade_printf(ctx->bb, NULL, NULL, "%s%sName: %s\n",
+                               ctx->prefix, info->label, s);
+            apr_brigade_printf(ctx->bb, NULL, NULL, "%s%sURL: %s\n",
+                               ctx->prefix, info->label, url);
+        }
+    }
 }
 
 static int count_certs(void *baton, const char *key, md_json_t *json)

--- a/src/mod_md_status.c
+++ b/src/mod_md_status.c
@@ -359,11 +359,11 @@ static void si_val_ca_url(status_ctx *ctx, md_json_t *mdj, const status_info *in
 
         proto = md_json_gets(jcert, MD_KEY_PROTO, NULL);
         s = url = md_json_gets(jcert, MD_KEY_URL, NULL);
-        if (url) {
-            s = md_get_ca_name_from_url(ctx->p, url);
-        }
-        if ((!s || !s[0]) && (proto && !strcmp(proto, "tailscale"))) {
+        if (proto && !strcmp(proto, "tailscale")) {
             s = "tailscale";
+        }
+        else if (url) {
+            s = md_get_ca_name_from_url(ctx->p, url);
         }
         if (HTML_STATUS(ctx)) {
             apr_brigade_printf(ctx->bb, NULL, NULL, "<a href='%s'>%s</a>",

--- a/test/modules/md/md_env.py
+++ b/test/modules/md/md_env.py
@@ -111,6 +111,7 @@ class MDTestEnv(HttpdTestEnv):
 
         self._a2md_bin = os.path.join(self.bin_dir, 'a2md')
         self._default_domain = f"test1.{self.http_tld}"
+        self._tailscale_domain = "test.headless-chicken.ts.net"
         self._store_dir = "./md"
         self.set_store_dir_default()
 
@@ -119,6 +120,7 @@ class MDTestEnv(HttpdTestEnv):
                             valid_from=timedelta(days=-100),
                             valid_to=timedelta(days=-10)),
             CertificateSpec(domains=["localhost"], key_type='rsa2048'),
+            CertificateSpec(domains=[self._tailscale_domain]),
         ])
 
     def setup_httpd(self, setup: HttpdTestSetup = None):
@@ -167,6 +169,10 @@ class MDTestEnv(HttpdTestEnv):
     @property
     def store_dir(self):
         return self._store_dir
+
+    @property
+    def tailscale_domain(self):
+        return self._tailscale_domain
 
     def get_request_domain(self, request):
         name = request.node.originalname if request.node.originalname else request.node.name

--- a/test/modules/md/test_780_tailscale.py
+++ b/test/modules/md/test_780_tailscale.py
@@ -1,19 +1,111 @@
 import os
+import re
+import socket
+import sys
+from threading import Thread
+
 import pytest
 
-from .md_env import MDTestEnv
 from .md_conf import MDConf
+
+
+class TailscaleFaker:
+
+    def __init__(self, env, path):
+        self.env = env
+        self._uds_path = path
+        self._done = False
+
+    def start(self):
+        def process(self):
+            self._socket.listen(1)
+            self._process()
+
+        try:
+            os.unlink(self._uds_path)
+        except OSError:
+            if os.path.exists(self._uds_path):
+                raise
+        self._socket = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+        self._socket.bind(self._uds_path)
+        self._thread = Thread(target=process, daemon=True, args=[self])
+        self._thread.start()
+
+    def stop(self):
+        self._done = True
+        self._socket.close()
+
+    def send_error(self, c, status, reason):
+        c.sendall(f"""HTTP/1.1 {status} {reason}\r
+Server: TailscaleFaker\r
+Content-Length: 0\r
+Connection: close\r
+\r
+""".encode())
+
+    def send_data(self, c, ctype: str, data: bytes):
+        c.sendall(f"""HTTP/1.1 200 OK\r
+Server: TailscaleFaker\r
+Content-Type: {ctype}\r
+Content-Length: {len(data)}\r
+Connection: close\r
+\r
+""".encode() + data)
+
+    def _process(self):
+        # a http server written on a sunny afternooon
+        while self._done is False:
+            try:
+                c, client_address = self._socket.accept()
+                try:
+                    data = c.recv(1024)
+                    lines = data.decode().splitlines()
+                    m = re.match(r'^(?P<method>\w+)\s+(?P<uri>\S+)\s+HTTP/1.1', lines[0])
+                    if m is None:
+                        self.send_error(c, 400, "Bad Request")
+                        continue
+                    uri = m.group('uri')
+                    m = re.match(r'/localapi/v0/cert/(?P<domain>\S+)\?type=(?P<type>\w+)', uri)
+                    if m is None:
+                        self.send_error(c, 404, "Not Found")
+                        continue
+                    domain = m.group('domain')
+                    cred_type = m.group('type')
+                    creds = self.env.get_credentials_for_name(domain)
+                    sys.stderr.write(f"lookup domain={domain}, type={cred_type} -> {creds}\n")
+                    if creds is None or len(creds) == 0:
+                        self.send_error(c, 404, "Not Found")
+                        continue
+                    if cred_type == 'crt':
+                        self.send_data(c, "text/plain", creds[0].cert_pem)
+                        pass
+                    elif cred_type == 'key':
+                        self.send_data(c, "text/plain", creds[0].pkey_pem)
+                    else:
+                        self.send_error(c, 404, "Not Found")
+                        continue
+                finally:
+                    c.close()
+
+            except ConnectionAbortedError:
+                self._done = True
 
 
 class TestTailscale:
 
     @pytest.fixture(autouse=True, scope='class')
     def _class_scope(self, env, acme):
+        UDS_PATH = f"{env.gen_dir}/tailscale.sock"
+        TestTailscale.UDS_PATH = UDS_PATH
+        faker = TailscaleFaker(env=env, path=UDS_PATH)
+        faker.start()
         env.APACHE_CONF_SRC = "data/test_auto"
         acme.start(config='default')
         env.clear_store()
         MDConf(env).install()
         assert env.apache_restart() == 0
+        yield
+        faker.stop()
 
     @pytest.fixture(autouse=True, scope='function')
     def _method_scope(self, env, request):
@@ -25,9 +117,9 @@ class TestTailscale:
             os.makedirs(doc_root)
         open(os.path.join(doc_root, name), "w").write(content)
 
-    # create a MD using `tailscale` as protocol
+    # create a MD using `tailscale` as protocol, wrong path
     def test_md_780_001(self, env):
-        domain = self.test_domain
+        domain = env.tailscale_domain
         # generate config with one MD
         domains = [domain]
         socket_path = '/xxx'
@@ -48,3 +140,47 @@ class TestTailscale:
         assert md['renewal']['last']['status-description'] == 'No such file or directory'
         assert md['renewal']['last']['detail'] == \
                f"tailscale socket not available, may not be up: {socket_path}"
+
+    # create a MD using `tailscale` as protocol, path to faker, should succeed
+    def test_md_780_002(self, env):
+        domain = env.tailscale_domain
+        # generate config with one MD
+        domains = [domain]
+        socket_path = '/xxx'
+        conf = MDConf(env, admin="admin@" + domain)
+        conf.start_md(domains)
+        conf.add([
+            "MDCertificateProtocol tailscale",
+            f"MDCertificateAuthority file://{self.UDS_PATH}",
+        ])
+        conf.end_md()
+        conf.add_vhost(domains)
+        conf.install()
+        # restart and watch it fail due to wrong tailscale unix socket path
+        assert env.apache_restart() == 0
+        assert env.await_completion(domains)
+        assert env.apache_restart() == 0
+        env.check_md_complete(domain)
+
+    # create a MD using `tailscale` as protocol, but domain name not assigned by tailscale
+    def test_md_780_003(self, env):
+        domain = "test.not-correct.ts.net"
+        # generate config with one MD
+        domains = [domain]
+        socket_path = '/xxx'
+        conf = MDConf(env, admin="admin@" + domain)
+        conf.start_md(domains)
+        conf.add([
+            "MDCertificateProtocol tailscale",
+            f"MDCertificateAuthority file://{self.UDS_PATH}",
+        ])
+        conf.end_md()
+        conf.add_vhost(domains)
+        conf.install()
+        # restart and watch it fail due to wrong tailscale unix socket path
+        assert env.apache_restart() == 0
+        md = env.await_error(domain)
+        assert md
+        assert md['renewal']['errors'] > 0
+        assert md['renewal']['last']['status-description'] == 'No such file or directory'
+        assert md['renewal']['last']['detail'] == "retrieving certificate from tailscale"

--- a/test/modules/md/test_780_tailscale.py
+++ b/test/modules/md/test_780_tailscale.py
@@ -1,0 +1,50 @@
+import os
+import pytest
+
+from .md_env import MDTestEnv
+from .md_conf import MDConf
+
+
+class TestTailscale:
+
+    @pytest.fixture(autouse=True, scope='class')
+    def _class_scope(self, env, acme):
+        env.APACHE_CONF_SRC = "data/test_auto"
+        acme.start(config='default')
+        env.clear_store()
+        MDConf(env).install()
+        assert env.apache_restart() == 0
+
+    @pytest.fixture(autouse=True, scope='function')
+    def _method_scope(self, env, request):
+        env.clear_store()
+        self.test_domain = env.get_request_domain(request)
+
+    def _write_res_file(self, doc_root, name, content):
+        if not os.path.exists(doc_root):
+            os.makedirs(doc_root)
+        open(os.path.join(doc_root, name), "w").write(content)
+
+    # create a MD using `tailscale` as protocol
+    def test_md_780_001(self, env):
+        domain = self.test_domain
+        # generate config with one MD
+        domains = [domain]
+        socket_path = '/xxx'
+        conf = MDConf(env, admin="admin@" + domain)
+        conf.start_md(domains)
+        conf.add([
+            "MDCertificateProtocol tailscale",
+            f"MDCertificateAuthority file://{socket_path}",
+        ])
+        conf.end_md()
+        conf.add_vhost(domains)
+        conf.install()
+        # restart and watch it fail due to wrong tailscale unix socket path
+        assert env.apache_restart() == 0
+        md = env.await_error(domain)
+        assert md
+        assert md['renewal']['errors'] > 0
+        assert md['renewal']['last']['status-description'] == 'No such file or directory'
+        assert md['renewal']['last']['detail'] == \
+               f"tailscale socket not available, may not be up: {socket_path}"


### PR DESCRIPTION
* add support for `MDCertificateProtocol tailscale` where the certificate for a domain is retrieved from the local tailscale daemon.