### PR TITLE
WIP: Allow MDChallengeDns01 directive globally or by domain

### DIFF
--- a/src/md.h
+++ b/src/md.h
@@ -103,7 +103,8 @@ struct md_t {
     
     struct apr_array_header_t *acme_tls_1_domains; /* domains supporting "acme-tls/1" protocol */
     int stapling;                   /* if OCSP stapling is enabled */
-    
+    const char *dns01_cmd           /* DNS challenge command, override global command */
+
     int watched;               /* if certificate is supervised (renew or expiration warning) */
     const struct md_srv_conf_t *sc; /* server config where it was defined or NULL */
     const char *defn_name;          /* config file this MD was defined */

--- a/src/md_acme_drive.c
+++ b/src/md_acme_drive.c
@@ -587,7 +587,9 @@ static apr_status_t acme_driver_init(md_proto_driver_t *d, md_result_t *result)
             ad->ca_challenges = md_array_str_remove(d->p, ad->ca_challenges, MD_AUTHZ_TYPE_TLSALPN01, 0);
             dis_alpn_acme = 1;
         }
-        if (!apr_table_get(d->env, MD_KEY_CMD_DNS01) && md_array_str_index(ad->ca_challenges, MD_AUTHZ_TYPE_DNS01, 0, 1) >= 0) {
+        if (!apr_table_get(d->env, MD_KEY_CMD_DNS01)
+            && NULL == d->md->dns01_cmd
+            && md_array_str_index(ad->ca_challenges, MD_AUTHZ_TYPE_DNS01, 0, 1) >= 0) {
             ad->ca_challenges = md_array_str_remove(d->p, ad->ca_challenges, MD_AUTHZ_TYPE_DNS01, 0);
             dis_dns = 1;
         }

--- a/src/mod_md_config.c
+++ b/src/mod_md_config.c
@@ -120,6 +120,7 @@ static md_srv_conf_t defconf = {
     NULL,                      /* ca eab hmac */
     0,                         /* stapling */
     1,                         /* staple others */
+    NULL,                      /* dns01_cmd */
     NULL,                      /* currently defined md */
     NULL,                      /* assigned md, post config */
     0,                         /* is_ssl, set during mod_ssl post_config */
@@ -174,6 +175,7 @@ static void srv_conf_props_clear(md_srv_conf_t *sc)
     sc->ca_eab_hmac = NULL;
     sc->stapling = DEF_VAL;
     sc->staple_others = DEF_VAL;
+    sc->dns01_cmd = NULL;
 }
 
 static void srv_conf_props_copy(md_srv_conf_t *to, const md_srv_conf_t *from)
@@ -194,6 +196,7 @@ static void srv_conf_props_copy(md_srv_conf_t *to, const md_srv_conf_t *from)
     to->ca_eab_hmac = from->ca_eab_hmac;
     to->stapling = from->stapling;
     to->staple_others = from->staple_others;
+    to->dns01_cmd = from->dns01_cmd;
 }
 
 static void srv_conf_props_apply(md_t *md, const md_srv_conf_t *from, apr_pool_t *p)
@@ -217,6 +220,7 @@ static void srv_conf_props_apply(md_t *md, const md_srv_conf_t *from, apr_pool_t
     if (from->ca_eab_kid) md->ca_eab_kid = from->ca_eab_kid;
     if (from->ca_eab_hmac) md->ca_eab_hmac = from->ca_eab_hmac;
     if (from->stapling != DEF_VAL) md->stapling = from->stapling;
+    if (from->dns01_cmd) md->dns01_cmd = from->dns01_cmd;
 }
 
 void *md_config_create_svr(apr_pool_t *pool, server_rec *s)
@@ -262,6 +266,7 @@ static void *md_config_merge(apr_pool_t *pool, void *basev, void *addv)
     nsc->ca_eab_hmac = add->ca_eab_hmac? add->ca_eab_hmac : base->ca_eab_hmac;
     nsc->stapling = (add->stapling != DEF_VAL)? add->stapling : base->stapling;
     nsc->staple_others = (add->staple_others != DEF_VAL)? add->staple_others : base->staple_others;
+    nsc->dns01_cmd = (add->dns01_cmd)? add->dns01_cmd : base->dns01_cmd;
     nsc->current = NULL;
     
     return nsc;
@@ -964,12 +969,19 @@ static const char *md_config_set_msg_cmd(cmd_parms *cmd, void *mconfig, const ch
 static const char *md_config_set_dns01_cmd(cmd_parms *cmd, void *mconfig, const char *arg)
 {
     md_srv_conf_t *sc = md_config_get(cmd->server);
+    md_srv_conf_t *config = md_config_get(cmd->server);
     const char *err;
 
-    if ((err = md_conf_check_location(cmd, MD_LOC_NOT_MD))) {
+    if ((err = md_conf_check_location(cmd, MD_LOC_ALL))) {
         return err;
     }
-    apr_table_set(sc->mc->env, MD_KEY_CMD_DNS01, arg);
+
+    if (inside_md_section(cmd)) {
+        config->dns01_cmd = arg;
+    } else {
+        apr_table_set(sc->mc->env, MD_KEY_CMD_DNS01, arg);
+    }
+
     (void)mconfig;
     return NULL;
 }

--- a/src/mod_md_config.c
+++ b/src/mod_md_config.c
@@ -969,7 +969,6 @@ static const char *md_config_set_msg_cmd(cmd_parms *cmd, void *mconfig, const ch
 static const char *md_config_set_dns01_cmd(cmd_parms *cmd, void *mconfig, const char *arg)
 {
     md_srv_conf_t *sc = md_config_get(cmd->server);
-    md_srv_conf_t *config = md_config_get(cmd->server);
     const char *err;
 
     if ((err = md_conf_check_location(cmd, MD_LOC_ALL))) {
@@ -977,7 +976,7 @@ static const char *md_config_set_dns01_cmd(cmd_parms *cmd, void *mconfig, const 
     }
 
     if (inside_md_section(cmd)) {
-        config->dns01_cmd = arg;
+        sc->dns01_cmd = arg;
     } else {
         apr_table_set(sc->mc->env, MD_KEY_CMD_DNS01, arg);
     }

--- a/src/mod_md_config.h
+++ b/src/mod_md_config.h
@@ -100,6 +100,8 @@ typedef struct md_srv_conf_t {
     int stapling;                      /* OCSP stapling enabled */
     int staple_others;                 /* Provide OCSP stapling for non-MD certificates */
 
+    const char *dns01_cmd              /* DNS challenge command, override global command */
+
     md_t *current;                     /* md currently defined in <MDomainSet xxx> section */
     struct apr_array_header_t *assigned; /* post_config: MDs that apply to this server */
     int is_ssl;                        /* SSLEngine is enabled here */


### PR DESCRIPTION
Allow to define `MDChallengeDns01` for a domain set or fallback to global one.


MR status :
- WIP
- Not tested
- Only config accept change. Global  `MDChallengeDns01` still used

Fix #305  