### PR TITLE
provide challenge to dns01 teardown command

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,8 @@
+ * New directive `MDChallengeDns01Version`. Setting this to `2` will provide
+   the command also with the challenge value on `teardown` invocation. In version
+   1, the default, only the `setup` invocation gets this parameter.
+   Refs #312. Thanks to @domrim for the idea.
+
 v2.4.22
 ----------------------------------------------------------------------------------------------------
  * For Managed Domain in "manual" mode, the checks if all used ServerName and

--- a/README.md
+++ b/README.md
@@ -1723,6 +1723,7 @@ checks by mod_md in v1.1.x which are now eliminated. If you have many domains, t
 * [MDCertificateProtocol](#mdcertificateprotocol)
 * [MDCertificateStatus](#mdcertificatestatus)
 * [MDChallengeDns01](#mdchallengedns01)
+* [MDChallengeDns01Version](#mdchallengedns01version)
 * [MDRenewMode](#mdrenewmode--renew-mode)
 * [MDMember](#mdmember)
 * [MDMembers](#mdmembers)
@@ -1856,7 +1857,8 @@ Wildcard certificates are possible with version 2.x of `mod_md`. But they are no
 
 When you configure a program to be called for these challenges, you may obtain them using `mod_md`. 
 The program is given the argument `setup` or `teardown` followed by the domain name. 
-For `setup` the challenge content is additionally given. 
+For `setup` the challenge content is additionally given. If you set `MDChallengeDns01Version` to `2`, the challenge
+is also given to the `teardown` command.
 
 The difficulty here is that Apache cannot do that on its own. (which is also a security benefit, since corrupting a web server or the communication path to it is the scenario `dns-01` protects against). As the name implies, `dns-01` requires you to show some specific DNS records for your domain that contain some challenge data. So you need to _write_ your domain's DNS records
 
@@ -1884,6 +1886,14 @@ and afterwards it will call
 ```
 
 Since version 2.4.21 of the module, you may configure `MDChallengeDns01` for each MDomain separately, if needed.
+
+## MDChallengeDns01Version
+
+`MDChallengeDns01Version 1|2`<BR/>
+Default: `1`
+
+Set the way `MDChallengeDns01` command is invoked, e.g the number and types of arguments. See `MDChallengeDns01` for the differences. This setting is global and cannot be varied per domain.
+
 
 ## MDCertificateFile
 ***A static certificate (chain) file for the MDomain***<BR/>

--- a/src/md.h
+++ b/src/md.h
@@ -128,6 +128,7 @@ struct md_t {
 #define MD_KEY_CHALLENGE        "challenge"
 #define MD_KEY_CHALLENGES       "challenges"
 #define MD_KEY_CMD_DNS01        "cmd-dns-01"
+#define MD_KEY_DNS01_VERSION    "cmd-dns-01-version"
 #define MD_KEY_COMPLETE         "complete"
 #define MD_KEY_CONTACT          "contact"
 #define MD_KEY_CONTACTS         "contacts"

--- a/src/mod_md_config.c
+++ b/src/mod_md_config.c
@@ -985,6 +985,24 @@ static const char *md_config_set_dns01_cmd(cmd_parms *cmd, void *mconfig, const 
     return NULL;
 }
 
+static const char *md_config_set_dns01_version(cmd_parms *cmd, void *mconfig, const char *value)
+{
+    md_srv_conf_t *sc = md_config_get(cmd->server);
+    const char *err;
+
+    (void)mconfig;
+    if ((err = md_conf_check_location(cmd, MD_LOC_NOT_MD))) {
+        return err;
+    }
+    if (!strcmp("1", value) || !strcmp("2", value)) {
+        apr_table_set(sc->mc->env, MD_KEY_DNS01_VERSION, value);
+    }
+    else {
+        return "Only versions `1` and `2` are supported";
+    }
+    return NULL;
+}
+
 static const char *md_config_add_cert_file(cmd_parms *cmd, void *mconfig, const char *arg)
 {
     md_srv_conf_t *sc = md_config_get(cmd->server);
@@ -1226,7 +1244,9 @@ const command_rec md_cmds[] = {
                   "Allow managing of base server outside virtual hosts."),
     AP_INIT_RAW_ARGS("MDChallengeDns01", md_config_set_dns01_cmd, NULL, RSRC_CONF, 
                   "Set the command for setup/teardown of dns-01 challenges"),
-    AP_INIT_TAKE1("MDCertificateFile", md_config_add_cert_file, NULL, RSRC_CONF, 
+    AP_INIT_TAKE1("MDChallengeDns01Version", md_config_set_dns01_version, NULL, RSRC_CONF,
+                  "Set the type of arguments to call `MDChallengeDns01` with"),
+    AP_INIT_TAKE1("MDCertificateFile", md_config_add_cert_file, NULL, RSRC_CONF,
                   "set the static certificate (chain) file to use for this domain."),
     AP_INIT_TAKE1("MDCertificateKeyFile", md_config_add_key_file, NULL, RSRC_CONF, 
                   "set the static private key file to use for this domain."),

--- a/test/modules/md/dns01_v2.py
+++ b/test/modules/md/dns01_v2.py
@@ -1,0 +1,62 @@
+#!/usr/bin/env python3
+
+import subprocess
+import sys
+
+curl = "curl"
+challtestsrv = "localhost:8055"
+
+
+def run(args):
+    sys.stderr.write(f"run: {' '.join(args)}\n")
+    p = subprocess.Popen(args, stdin=None, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    output, errput = p.communicate(None)
+    rv = p.wait()
+    if rv != 0:
+        sys.stderr.write(errput.decode())
+    sys.stdout.write(output.decode())
+    return rv
+
+
+def teardown(domain):
+    rv = run([curl, '-s', '-d', f'{{"host":"_acme-challenge.{domain}"}}',
+              f'{challtestsrv}/clear-txt'])
+    if rv == 0:
+        rv = run([curl, '-s', '-d', f'{{"host":"{domain}"}}',
+                  f'{challtestsrv}/set-txt'])
+    return rv
+
+
+def setup(domain, challenge):
+    teardown(domain)
+    rv = run([curl, '-s', '-d', f'{{"host":"{domain}", "addresses":["127.0.0.1"]}}',
+              f'{challtestsrv}/set-txt'])
+    if rv == 0:
+        rv = run([curl, '-s', '-d', f'{{"host":"_acme-challenge.{domain}.", "value":"{challenge}"}}',
+                  f'{challtestsrv}/set-txt'])
+    return rv
+
+
+def main(argv):
+    if len(argv) > 1:
+        if argv[1] == 'setup':
+            if len(argv) != 4:
+                sys.stderr.write("wrong number of arguments: dns01.py setup <domain> <challenge>\n")
+                sys.exit(2)
+            rv = setup(argv[2], argv[3])
+        elif argv[1] == 'teardown':
+            if len(argv) != 4:
+                sys.stderr.write("wrong number of arguments: dns01.py teardown <domain> <challenge>\n")
+                sys.exit(1)
+            rv = teardown(argv[2])
+        else:
+            sys.stderr.write(f"unknown option {argv[1]}\n")
+            rv = 2
+    else:
+        sys.stderr.write("dns01.py wrong number of arguments\n")
+        rv = 2
+    sys.exit(rv)
+
+
+if __name__ == "__main__":
+    main(sys.argv)


### PR DESCRIPTION
 * New directive `MDChallengeDns01Version`. Setting this to `2` will provide
   the command also with the challenge value on `teardown` invocation. In version
   1, the default, only the `setup` invocation gets this parameter.
   Refs #312. Thanks to @domrim for the idea.