### PR TITLE
Fix environment inheritance when executing commands

### DIFF
--- a/src/md_acme_authz.c
+++ b/src/md_acme_authz.c
@@ -463,7 +463,7 @@ static apr_status_t cha_dns_01_setup(md_acme_authz_cha_t *cha, md_acme_authz_t *
                   "%s: dns-01 setup command: %s", authz->domain, cmdline);
 
     apr_tokenize_to_argv(cmdline, (char***)&argv, p);
-    if (APR_SUCCESS != (rv = md_util_exec(p, argv[0], argv, NULL, &exit_code))) {
+    if (APR_SUCCESS != (rv = md_util_exec(p, argv[0], argv, &exit_code))) {
         md_log_perror(MD_LOG_MARK, MD_LOG_WARNING, rv, p, 
                       "%s: dns-01 setup command failed to execute for %s", md->name, authz->domain);
         goto out;
@@ -531,7 +531,7 @@ static apr_status_t cha_dns_01_teardown(md_store_t *store, const char *domain, c
 
     cmdline = apr_psprintf(p, "%s teardown %s", dns01_cmd, domain); 
     apr_tokenize_to_argv(cmdline, (char***)&argv, p);
-    if (APR_SUCCESS != (rv = md_util_exec(p, argv[0], argv, NULL, &exit_code)) || exit_code) {
+    if (APR_SUCCESS != (rv = md_util_exec(p, argv[0], argv, &exit_code)) || exit_code) {
         md_log_perror(MD_LOG_MARK, MD_LOG_WARNING, rv, p, 
                       "%s: dns-01 teardown command failed (exit code=%d) for %s",
                       md->name, exit_code, domain);

--- a/src/md_util.c
+++ b/src/md_util.c
@@ -1081,32 +1081,24 @@ apr_status_t md_util_try(md_util_try_fn *fn, void *baton, int ignore_errs,
 
 /* execute process ********************************************************************************/
 
-apr_status_t md_util_exec(apr_pool_t *p, const char *cmd, const char * const *argv,
-                          apr_array_header_t *env, int *exit_code)
+apr_status_t md_util_exec(apr_pool_t *p, const char *cmd,
+                          const char * const *argv, int *exit_code)
 {
     apr_status_t rv;
     apr_procattr_t *procattr;
     apr_proc_t *proc;
     apr_exit_why_e ewhy;
-    const char * const *envp = NULL;
     char buffer[1024];
     
     *exit_code = 0;
     if (!(proc = apr_pcalloc(p, sizeof(*proc)))) {
         return APR_ENOMEM;
     }
-    if (env && env->nelts > 0) {
-        apr_array_header_t *nenv;
-        
-        nenv = apr_array_copy(p, env);
-        APR_ARRAY_PUSH(nenv, const char *) = NULL;
-        envp = (const char * const *)nenv->elts;
-    }
     if (   APR_SUCCESS == (rv = apr_procattr_create(&procattr, p))
         && APR_SUCCESS == (rv = apr_procattr_io_set(procattr, APR_NO_FILE, 
                                                     APR_NO_PIPE, APR_FULL_BLOCK))
-        && APR_SUCCESS == (rv = apr_procattr_cmdtype_set(procattr, APR_PROGRAM))
-        && APR_SUCCESS == (rv = apr_proc_create(proc, cmd, argv, envp, procattr, p))) {
+        && APR_SUCCESS == (rv = apr_procattr_cmdtype_set(procattr, APR_PROGRAM_ENV))
+        && APR_SUCCESS == (rv = apr_proc_create(proc, cmd, argv, NULL, procattr, p))) {
         
         /* read stderr and log on INFO for possible fault analysis. */
         while(APR_SUCCESS == (rv = apr_file_gets(buffer, sizeof(buffer)-1, proc->err))) {

--- a/src/md_util.h
+++ b/src/md_util.h
@@ -133,7 +133,7 @@ int md_array_str_add_missing(struct apr_array_header_t *dest,
 /* process execution */
 
 apr_status_t md_util_exec(apr_pool_t *p, const char *cmd, const char * const *argv,
-                          struct apr_array_header_t *env, int *exit_code);
+                          int *exit_code);
 
 /**************************************************************************************************/
 /* dns name check */

--- a/src/mod_md.c
+++ b/src/mod_md.c
@@ -183,7 +183,7 @@ static apr_status_t notify(md_job_t *job, const char *reason,
         if (mc->notify_cmd) {
             cmdline = apr_psprintf(p, "%s %s", mc->notify_cmd, job->mdomain);
             apr_tokenize_to_argv(cmdline, (char***)&argv, p);
-            rv = md_util_exec(p, argv[0], argv, NULL, &exit_code);
+            rv = md_util_exec(p, argv[0], argv, &exit_code);
 
             if (APR_SUCCESS == rv && exit_code) rv = APR_EGENERAL;
             if (APR_SUCCESS != rv) {
@@ -202,7 +202,7 @@ static apr_status_t notify(md_job_t *job, const char *reason,
     if (mc->message_cmd) {
         cmdline = apr_psprintf(p, "%s %s %s", mc->message_cmd, reason, job->mdomain);
         apr_tokenize_to_argv(cmdline, (char***)&argv, p);
-        rv = md_util_exec(p, argv[0], argv, NULL, &exit_code);
+        rv = md_util_exec(p, argv[0], argv, &exit_code);
 
         if (APR_SUCCESS == rv && exit_code) rv = APR_EGENERAL;
         if (APR_SUCCESS != rv) {


### PR DESCRIPTION
- refs #319
- use APR_PROGRAM_ENV instead of APR_PROGRAM when executing commands like `MDMessageCmd`. This results in the httpd environment being inherited by the invoked process on operating systems like Linux. On others, like Windows, it makes no difference, looking at the implementation in the Apache Runtime.