### PR TITLE
Fix deref of possible NULL pointer when ACME server responded with error

### DIFF
--- a/src/md_acme_order.c
+++ b/src/md_acme_order.c
@@ -537,8 +537,8 @@ static apr_status_t check_challenges(void *baton, int attempt)
             }
         }
         else {
-            md_result_printf(ctx->result, rv, "authorization retrieval failed for domain %s", 
-                             authz->domain);
+            md_result_printf(ctx->result, rv, "authorization retrieval failed for %s on <%s>",
+                             ctx->name, url);
         }
     }
 leave:


### PR DESCRIPTION
- refs #324
- when an order could not be retrieved from the ACME server, this was logged using the NULL item which could not be retrieved. Now reporting the context name and the URL in error