### PR TITLE
accept OCSP responses with no nextUpdate

### DIFF
--- a/src/md_ocsp.c
+++ b/src/md_ocsp.c
@@ -683,12 +683,6 @@ static apr_status_t ostat_on_resp(const md_http_response_t *resp, void *baton)
         md_result_log(update->result, MD_LOG_DEBUG);
         goto cleanup;
     }
-    if (!bnextup) {
-        rv = APR_EINVAL;
-        md_result_set(update->result, rv, "OCSP basicresponse reports not valid dates");
-        md_result_log(update->result, MD_LOG_DEBUG);
-        goto cleanup;
-    }
     
     /* Coming here, we have a response for our certid and it is either GOOD
      * or REVOKED. Both cases we want to remember and use in stapling. */
@@ -703,7 +697,14 @@ static apr_status_t ostat_on_resp(const md_http_response_t *resp, void *baton)
     new_der.free_data = md_openssl_free;
     nstat = (bstatus == V_OCSP_CERTSTATUS_GOOD)? MD_OCSP_CERT_ST_GOOD : MD_OCSP_CERT_ST_REVOKED;
     valid.start = bup? md_asn1_generalized_time_get(bup) : apr_time_now();
-    valid.end = md_asn1_generalized_time_get(bnextup);
+    if (bnextup) {
+        valid.end = md_asn1_generalized_time_get(bnextup);
+    }
+    else {
+        // nextUpdate not set; default to 12 hours.
+        // Refresh attempts will be started some time earlier.
+        valid.end = valid.start + apr_time_from_sec(MD_SECS_PER_DAY / 2);
+    }
     
     /* First, update the instance with a copy */
     apr_thread_mutex_lock(ostat->reg->mutex);


### PR DESCRIPTION
mod_md rejects OCSP response when nextUpdate field is not set. However, per RFC 6960 this is valid (in particular see section 4.2.2.1):

    If nextUpdate is not set, the responder is indicating that newer
    revocation information is available all the time.

Update mod_md to accept these responses.  When `!bnextup`, set `valid.end` to `valid.start` plus 12 hours.  mod_md will attempt to refresh the response at some earlier time, according to the `MDStaplingRenewWindow` setting.

Fixes: https://github.com/icing/mod_md/issues/326