### PR TITLE
Renew certificates when one is known to be OCSP revoked.

### DIFF
--- a/src/md_reg.h
+++ b/src/md_reg.h
@@ -23,6 +23,7 @@ struct md_pkey_t;
 struct md_cert_t;
 struct md_result_t;
 struct md_pkey_spec_t;
+struct md_ocsp_reg_t;
 
 #include "md_store.h"
 
@@ -309,5 +310,11 @@ apr_status_t md_reg_lock_global(md_reg_t *reg, apr_pool_t *p);
  * Realease the global registry lock. Will do nothing if there is no lock.
  */
 void md_reg_unlock_global(md_reg_t *reg, apr_pool_t *p);
+
+/**
+ * @return != 0 iff `md` has any certificates known to be REVOKED.
+ */
+int md_reg_has_revoked_certs(md_reg_t *reg, struct md_ocsp_reg_t *ocsp,
+                             const md_t *md, apr_pool_t *p);
 
 #endif /* mod_md_md_reg_h */

--- a/src/mod_md_config.h
+++ b/src/mod_md_config.h
@@ -75,6 +75,7 @@ struct md_mod_conf_t {
     const char *cert_check_name;       /* name of the linked certificate check site */
     const char *cert_check_url;        /* url "template for" checking a certificate */
     const char *ca_certs;              /* root certificates to use for connections */
+    apr_time_t check_interval;         /* duration between cert renewal checks */
     apr_time_t min_delay;              /* minimum delay for retries */
     int retry_failover;                /* number of errors to trigger CA failover */
     int use_store_locks;               /* use locks when updating store */

--- a/src/mod_md_drive.c
+++ b/src/mod_md_drive.c
@@ -100,7 +100,7 @@ static void process_drive_job(md_renew_ctx_t *dctx, md_job_t *job, apr_pool_t *p
     }
     
     if (md_will_renew_cert(md)) {
-        /* Renew the MDs credentials in a STAGING area. Might be invoked repeatedly 
+        /* Renew the MDs credentials in a STAGING area. Might be invoked repeatedly
          * without discarding previous/intermediate results.
          * Only returns SUCCESS when the renewal is complete, e.g. STAGING has a
          * complete set of new credentials.
@@ -108,7 +108,12 @@ static void process_drive_job(md_renew_ctx_t *dctx, md_job_t *job, apr_pool_t *p
         ap_log_error( APLOG_MARK, APLOG_DEBUG, 0, dctx->s, APLOGNO(10052) 
                      "md(%s): state=%d, driving", job->mdomain, md->state);
 
-        if (!md_reg_should_renew(dctx->mc->reg, md, dctx->p)) {
+        if (md->stapling && dctx->mc->ocsp &&
+            md_reg_has_revoked_certs(dctx->mc->reg, dctx->mc->ocsp, md, dctx->p)) {
+            ap_log_error( APLOG_MARK, APLOG_DEBUG, 0, dctx->s, APLOGNO()
+                         "md(%s): has revoked certificates", job->mdomain);
+        }
+        else if (!md_reg_should_renew(dctx->mc->reg, md, dctx->p)) {
             ap_log_error( APLOG_MARK, APLOG_DEBUG, 0, dctx->s, APLOGNO(10053) 
                          "md(%s): no need to renew", job->mdomain);
             goto expiry;

--- a/test/modules/md/conftest.py
+++ b/test/modules/md/conftest.py
@@ -32,7 +32,8 @@ def env(pytestconfig) -> MDTestEnv:
     env.setup_httpd()
     env.apache_access_log_clear()
     env.httpd_error_log.clear_log()
-    return env
+    yield env
+    env.apache_stop()
 
 
 @pytest.fixture(autouse=True, scope="package")


### PR DESCRIPTION
- refs #328 where @frasertweedale proposed this
- when checking on renewal of an MDomain, inspect known OCSP status for REVOKED answers. If found, renew MD.