### PR TITLE
Changes to make tests work with pebble v2.5

### DIFF
--- a/test/modules/md/md_cert_util.py
+++ b/test/modules/md/md_cert_util.py
@@ -166,10 +166,10 @@ class MDCertUtil(object):
 
     def get_san_list(self):
         text = OpenSSL.crypto.dump_certificate(OpenSSL.crypto.FILETYPE_TEXT, self.cert).decode("utf-8")
-        m = re.search(r"X509v3 Subject Alternative Name:\s*(.*)", text)
+        m = re.search(r"X509v3 Subject Alternative Name:(\s+critical)?\s*(.*)", text)
         sans_list = []
         if m:
-            sans_list = m.group(1).split(",")
+            sans_list = m.group(2).split(",")
 
         def _strip_prefix(s):
             return s.split(":")[1] if s.strip().startswith("DNS:") else s.strip()

--- a/test/modules/md/test_750_eab.py
+++ b/test/modules/md/test_750_eab.py
@@ -82,14 +82,17 @@ class TestEab:
         assert env.apache_restart() == 0
         md = env.await_error(domain)
         assert md['renewal']['errors'] > 0
-        assert md['renewal']['last']['problem'] == 'urn:ietf:params:acme:error:unauthorized'
+        assert md['renewal']['last']['problem'] in [
+            'urn:ietf:params:acme:error:unauthorized',
+            'urn:ietf:params:acme:error:malformed',
+        ]
         #
         env.httpd_error_log.ignore_recent(
             lognos = [
                 "AH10056"   # the field 'kid' references a key that is not known to the ACME server
             ],
             matches = [
-                r'.*urn:ietf:params:acme:error:unauthorized.*'
+                r'.*urn:ietf:params:acme:error:(unauthorized|malformed).*'
             ]
         )
 
@@ -105,14 +108,17 @@ class TestEab:
         assert env.apache_restart() == 0
         md = env.await_error(domain)
         assert md['renewal']['errors'] > 0
-        assert md['renewal']['last']['problem'] == 'urn:ietf:params:acme:error:unauthorized'
+        assert md['renewal']['last']['problem'] in [
+            'urn:ietf:params:acme:error:unauthorized',
+            'urn:ietf:params:acme:error:malformed',
+        ]
         #
         env.httpd_error_log.ignore_recent(
             lognos = [
                 "AH10056"   # the field 'kid' references a key that is not known to the ACME server
             ],
             matches = [
-                r'.*urn:ietf:params:acme:error:unauthorized.*'
+                r'.*urn:ietf:params:acme:error:(unauthorized|malformed).*'
             ]
         )
 
@@ -128,14 +134,17 @@ class TestEab:
         assert env.apache_restart() == 0
         md = env.await_error(domain)
         assert md['renewal']['errors'] > 0
-        assert md['renewal']['last']['problem'] == 'urn:ietf:params:acme:error:unauthorized'
+        assert md['renewal']['last']['problem'] in [
+            'urn:ietf:params:acme:error:unauthorized',
+            'urn:ietf:params:acme:error:malformed',
+        ]
         #
         env.httpd_error_log.ignore_recent(
             lognos = [
                 "AH10056"   # external account binding JWS verification error: square/go-jose: error in cryptographic primitive
             ],
             matches = [
-                r'.*urn:ietf:params:acme:error:unauthorized.*'
+                r'.*urn:ietf:params:acme:error:(unauthorized|malformed).*'
             ]
         )
 


### PR DESCRIPTION
- accept SAN names from certs being marked as `critical`
- disable EAB capabilities since pebble no longer supports HS256 JWT