### PR TITLE
add github workflow for linux with pytest and pebble

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -39,33 +39,62 @@ env:
   CFLAGS: "-g"
 
 jobs:
-  build:
+  linux:
     name: ${{ matrix.name }}
     runs-on: ubuntu-latest
     timeout-minutes: 30
     strategy:
       fail-fast: false
       matrix:
-        include:
+        build:
           - name: Default
             install_packages:
-            install_steps: pytest
+            install_steps: pytest pebble
 
-  steps:
-    - name: 'install prereqs'
-      run: |
-        sudo apt-get update -y
-        sudo apt-get install -y --no-install-suggests --no-install-recommends \
-          libtool autoconf automake pkgconf apache2 apache2-dev openssl \
-          libssl-dev libjansson-dev libcurl4-openssl-dev \
-          ${{ matrix.build.install_packages }}
-        python3 -m venv $HOME/venv
+    steps:
+      - name: 'install prereqs'
+        run: |
+          sudo apt-get update -y
+          sudo apt-get install -y --no-install-suggests --no-install-recommends \
+            libtool autoconf automake pkgconf apache2 apache2-dev openssl \
+            curl nghttp2-client libssl-dev libjansson-dev libcurl4-openssl-dev \
+            ${{ matrix.build.install_packages }}
+          python3 -m venv $HOME/venv
 
-    - name: 'configure'
-      run: |
-        autoreconf -fi
-        ./configure --enable-werror
+      - uses: actions/checkout@v4
 
-    - name: 'build'
-      run: |
-        make V=1
+      - name: 'install test prereqs'
+        run: |
+          [ -x "$HOME/venv/bin/activate" ] && source $HOME/venv/bin/activate
+          python3 -m pip install -r test/requirements.txt
+
+      - name: setup Go
+        if: contains(matrix.build.install_steps, 'pebble')
+        uses: actions/setup-go@v5
+
+      - name: install pebble
+        if: contains(matrix.build.install_steps, 'pebble')
+        run: |
+          export PATH=$PATH:$HOME/go/bin
+          git clone --quiet --depth=1 https://github.com/letsencrypt/pebble/
+          cd pebble
+          go install ./cmd/pebble
+          go install ./cmd/pebble-challtestsrv
+
+      - name: 'configure'
+        run: |
+          export PATH=$PATH:$HOME/go/bin
+          autoreconf -fi
+          ./configure --enable-werror
+
+      - name: 'build'
+        run: make V=1
+
+      - name: pytest
+        if: contains(matrix.build.install_steps, 'pytest')
+        env:
+          PYTEST_ADDOPTS: "--color=yes"
+        run: |
+          export PATH=$PATH:$HOME/go/bin
+          [ -x "$HOME/venv/bin/activate" ] && source $HOME/venv/bin/activate
+          pytest -v

--- a/configure.ac
+++ b/configure.ac
@@ -117,24 +117,37 @@ CPPFLAGS="-I$($APXS -q includedir) -I$($APXS -q APR_INCLUDEDIR) $($APXS -q EXTRA
 HTTPD_VERSION="$($APXS -q HTTPD_VERSION)"
 AC_SUBST(HTTPD_VERSION)
 
-APACHECTL="$sbindir/apachectl"
-if test ! -x "$APACHECTL"; then
-    # rogue distros rename things! =)
-    APACHECTL="$sbindir/apache2ctl"
-fi
-AC_SUBST(APACHECTL)
-
-if test -x "$APACHECTL"; then
-    DSO_MODULES="$($APACHECTL -t -D DUMP_MODULES | fgrep '(shared)'| sed 's/_module.*//g'|tr -d \\n)"
-    AC_SUBST(DSO_MODULES)
-    STATIC_MODULES="$($APACHECTL -t -D DUMP_MODULES | fgrep '(static)'| sed 's/_module.*//g'|tr -d \\n)"
-    AC_SUBST(STATIC_MODULES)
-    MPM_MODULES="mpm_event mpm_worker"
-    AC_SUBST(MPM_MODULES)
+HTTPD="$sbindir/httpd"
+if test -x "$HTTPD"; then
+  :  # all fine
 else
-    AC_MSG_WARN("apachectl not found in '$BINDIR', test suite will not work!")
-    APACHECTL=""
+  HTTPD="$sbindir/apache2"
+  if test -x "$HTTPD"; then
+    :  # all fine
+  else
+    HTTPD=""
+    AC_PATH_PROG([HTTPD], [httpd])
+    if test -x "$HTTPD"; then
+      :  # ok
+    else
+      HTTPD=""
+      AC_PATH_PROG([HTTPD], [apache2])
+      if test -x "$HTTPD"; then
+        :  # ok
+      else
+        AC_MSG_ERROR([httpd/apache2 not in PATH])
+      fi
+    fi
+  fi
 fi
+AC_SUBST(HTTPD)
+
+DSO_MODULES="$($HTTPD -t -D DUMP_MODULES | fgrep '(shared)'| sed 's/_module.*//g'|tr -d \\n)"
+AC_SUBST(DSO_MODULES)
+STATIC_MODULES="$($HTTPD -t -D DUMP_MODULES | fgrep '(static)'| sed 's/_module.*//g'|tr -d \\n)"
+AC_SUBST(STATIC_MODULES)
+MPM_MODULES="mpm_event mpm_worker"
+AC_SUBST(MPM_MODULES)
 
 # We need a JSON lib, like jansson
 #
@@ -459,6 +472,7 @@ AC_MSG_NOTICE([summary of build options:
     Install prefix: ${prefix}
     APXS:           ${APXS}
     HTTPD-VERSION:  ${HTTPD_VERSION}
+    HTTPD:          ${HTTPD}
     C compiler:     ${CC} ${COMPILER_VERSION}
     CFLAGS:         ${CFLAGS}
     WARNCFLAGS:     ${WERROR_CFLAGS}

--- a/test/modules/md/conftest.py
+++ b/test/modules/md/conftest.py
@@ -5,12 +5,11 @@ import pytest
 
 sys.path.append(os.path.join(os.path.dirname(__file__), '../..'))
 
-from .md_conf import HttpdConf
 from .md_env import MDTestEnv
 from .md_acme import MDPebbleRunner, MDBoulderRunner
 
 
-def pytest_report_header(config, startdir):
+def pytest_report_header(config):
     env = MDTestEnv()
     return "mod_md: [apache: {aversion}({prefix}), mod_{ssl}, ACME server: {acme}]".format(
         prefix=env.prefix,

--- a/test/modules/md/test_010_store_migrate.py
+++ b/test/modules/md/test_010_store_migrate.py
@@ -13,7 +13,7 @@ class TestStoreMigrate:
     @pytest.fixture(autouse=True, scope='class')
     def _class_scope(self, env):
         MDConf(env).install()
-        assert env.apache_restart() == 0
+        assert env.apache_restart() == 0, f'{env.apachectl_stderr}'
 
     # install old store, start a2md list, check files afterwards
     def test_md_010_000(self, env):

--- a/test/modules/md/test_202_acmev2_regs.py
+++ b/test/modules/md/test_202_acmev2_regs.py
@@ -19,7 +19,7 @@ class TestAcmeAcc:
         env.check_acme()
         env.APACHE_CONF_SRC = "data/test_drive"
         MDConf(env).install()
-        assert env.apache_restart() == 0
+        assert env.apache_restart() == 0, f'{env.apachectl_stderr}'
 
     @pytest.fixture(autouse=True, scope='function')
     def _method_scope(self, env):

--- a/test/modules/md/test_300_conf_validate.py
+++ b/test/modules/md/test_300_conf_validate.py
@@ -24,7 +24,7 @@ class TestConf:
         MDConf(env, text="""
             MDomain not-forbidden.org www.not-forbidden.org mail.not-forbidden.org
             """).install()
-        assert env.apache_restart() == 0
+        assert env.apache_restart() == 0, f'{env.apachectl_stderr}'
         #
         env.httpd_error_log.ignore_recent(
             lognos = [
@@ -38,7 +38,7 @@ class TestConf:
             MDomain not-forbidden.org www.not-forbidden.org mail.not-forbidden.org
             MDomain example2.org www.example2.org mail.example2.org
             """).install()
-        assert env.apache_restart() == 0
+        assert env.apache_restart() == 0, f'{env.apachectl_stderr}'
         #
         env.httpd_error_log.ignore_recent(
             lognos = [
@@ -84,7 +84,7 @@ class TestConf:
                 MDomain example2.org www.example2.org www.example3.org
             </VirtualHost>
             """).install()
-        assert env.apache_restart() == 0
+        assert env.apache_restart() == 0, f'{env.apachectl_stderr}'
         #
         env.httpd_error_log.ignore_recent(
             lognos = [
@@ -101,7 +101,7 @@ class TestConf:
                 MDomain example2.org www.example2.org www.example3.org
             </VirtualHost>
             """).install()
-        assert env.apache_restart() == 0
+        assert env.apache_restart() == 0, f'{env.apachectl_stderr}'
         #
         env.httpd_error_log.ignore_recent(
             lognos = [
@@ -121,7 +121,7 @@ class TestConf:
                 ServerName www.example2.org
             </VirtualHost>
             """).install()
-        assert env.apache_restart() == 0
+        assert env.apache_restart() == 0, f'{env.apachectl_stderr}'
         #
         env.httpd_error_log.ignore_recent(
             lognos = [
@@ -144,7 +144,7 @@ class TestConf:
                 ServerAlias example2.org
             </VirtualHost>
             """).install()
-        assert env.apache_restart() == 0
+        assert env.apache_restart() == 0, f'{env.apachectl_stderr}'
         #
         env.httpd_error_log.ignore_recent(
             lognos = [
@@ -186,7 +186,7 @@ class TestConf:
             </VirtualHost>
             """)
         conf.install()
-        assert env.apache_restart() == 0
+        assert env.apache_restart() == 0, f'{env.apachectl_stderr}'
 
     # test case: MDomain, misses one ServerAlias
     def test_md_300_011a(self, env):
@@ -216,7 +216,7 @@ class TestConf:
                 ServerAlias test4.not-forbidden.org
             </VirtualHost>
             """ % env.https_port).install()
-        assert env.apache_restart() == 0
+        assert env.apache_restart() == 0, f'{env.apachectl_stderr}'
 
     # test case: MDomain does not match any vhost
     def test_md_300_012(self, env):
@@ -227,7 +227,7 @@ class TestConf:
                 ServerAlias test3.not-forbidden.org
             </VirtualHost>
             """).install()
-        assert env.apache_restart() == 0
+        assert env.apache_restart() == 0, f'{env.apachectl_stderr}'
         #
         env.httpd_error_log.ignore_recent(
             lognos = [
@@ -246,7 +246,7 @@ class TestConf:
                 ServerName test-b.example2.org
             </VirtualHost>
             """).install()
-        assert env.apache_restart() == 0
+        assert env.apache_restart() == 0, f'{env.apachectl_stderr}'
 
     # test case: global server name as managed domain name
     def test_md_300_014(self, env):
@@ -257,7 +257,7 @@ class TestConf:
                 ServerName www.example2.org
             </VirtualHost>
             """).install()
-        assert env.apache_restart() == 0
+        assert env.apache_restart() == 0, f'{env.apachectl_stderr}'
 
     # test case: valid pkey specification
     def test_md_300_015(self, env):
@@ -268,7 +268,7 @@ class TestConf:
             MDPrivateKeys RSA 3072
             MDPrivateKeys RSA 4096
             """).install()
-        assert env.apache_restart() == 0
+        assert env.apache_restart() == 0, f'{env.apachectl_stderr}'
 
     # test case: invalid pkey specification
     @pytest.mark.parametrize("line,exp_err_msg", [
@@ -355,7 +355,7 @@ class TestConf:
                 ServerName secret.com
             </VirtualHost>
             """).install()
-        assert env.apache_restart() == 0
+        assert env.apache_restart() == 0, f'{env.apachectl_stderr}'
         #
         env.httpd_error_log.ignore_recent(
             lognos = [
@@ -431,7 +431,7 @@ class TestConf:
             </VirtualHost>
             """)
         conf.install()
-        assert env.apache_restart() == 0
+        assert env.apache_restart() == 0, f'{env.apachectl_stderr}'
 
     # test case: configure more than 1 CA
     @pytest.mark.parametrize("cas, should_work", [
@@ -493,7 +493,7 @@ class TestConf:
         # It works, if we only match on ServerNames
         conf.add("MDMatchNames servernames")
         conf.install()
-        assert env.apache_restart() == 0
+        assert env.apache_restart() == 0, f'{env.apachectl_stderr}'
         env.httpd_error_log.ignore_recent(
             lognos=[
                 "AH10040",  # ServerAlias not covered
@@ -537,7 +537,7 @@ class TestConf:
         # It works, if we only match on ServerNames
         conf.add("MDMatchNames servernames")
         conf.install()
-        assert env.apache_restart() == 0
+        assert env.apache_restart() == 0, f'{env.apachectl_stderr}'
         time.sleep(2)
         assert env.apache_stop() == 0
         # we need dns-01 challenge for the wildcard, which is not configured

--- a/test/modules/md/test_310_conf_store.py
+++ b/test/modules/md/test_310_conf_store.py
@@ -30,7 +30,7 @@ class TestConf:
     # test case: no md definitions in config
     def test_md_310_001(self, env):
         MDConf(env, text="").install()
-        assert env.apache_restart() == 0
+        assert env.apache_restart() == 0, f'{env.apachectl_stderr}'
         r = env.a2md(["list"])
         assert 0 == len(r.json["output"])
 
@@ -45,7 +45,7 @@ class TestConf:
     ])
     def test_md_310_100(self, env, confline, dns_lists, md_count):
         MDConf(env, text=confline).install()
-        assert env.apache_restart() == 0
+        assert env.apache_restart() == 0, f'{env.apachectl_stderr}'
         for i in range(0, len(dns_lists)):
             env.check_md(dns_lists[i], state=1)
 
@@ -54,13 +54,13 @@ class TestConf:
         MDConf(env, text="""
             MDomain testdomain.org www.testdomain.org mail.testdomain.org
             """).install()
-        assert env.apache_restart() == 0
+        assert env.apache_restart() == 0, f'{env.apachectl_stderr}'
         env.check_md(["testdomain.org", "www.testdomain.org", "mail.testdomain.org"], state=1)
         MDConf(env, text="""
             MDomain testdomain.org www.testdomain.org mail.testdomain.org
             MDomain testdomain2.org www.testdomain2.org mail.testdomain2.org
             """).install()
-        assert env.apache_restart() == 0
+        assert env.apache_restart() == 0, f'{env.apachectl_stderr}'
         env.check_md(["testdomain.org", "www.testdomain.org", "mail.testdomain.org"], state=1)
         env.check_md(["testdomain2.org", "www.testdomain2.org", "mail.testdomain2.org"], state=1)
 
@@ -70,7 +70,7 @@ class TestConf:
         MDConf(env, text="""
             MDomain testdomain.org www.testdomain.org mail.testdomain.org
             """).install()
-        assert env.apache_restart() == 0
+        assert env.apache_restart() == 0, f'{env.apachectl_stderr}'
         env.check_md(["testdomain.org", "www.testdomain.org", "mail.testdomain.org"], state=1)
 
     # test case: add new md definition with acme url, acme protocol, acme agreement
@@ -82,7 +82,7 @@ class TestConf:
 
             MDomain testdomain.org www.testdomain.org mail.testdomain.org
             """, local_ca=False).install()
-        assert env.apache_restart() == 0
+        assert env.apache_restart() == 0, f'{env.apachectl_stderr}'
         name = "testdomain.org"
         env.check_md([name, "www.testdomain.org", "mail.testdomain.org"], state=1,
                      ca="http://acme.test.org:4000/directory", protocol="ACME",
@@ -94,7 +94,7 @@ class TestConf:
         MDConf(env, local_ca=False, text="""
             MDomain testdomain.org www.testdomain.org mail.testdomain.org
             """).install()
-        assert env.apache_restart() == 0
+        assert env.apache_restart() == 0, f'{env.apachectl_stderr}'
         env.check_md([name, "www.testdomain.org", "mail.testdomain.org"], state=1,
                      ca="https://acme-v02.api.letsencrypt.org/directory", protocol="ACME")
         MDConf(env, local_ca=False, text="""
@@ -104,7 +104,7 @@ class TestConf:
 
             MDomain testdomain.org www.testdomain.org mail.testdomain.org
             """).install()
-        assert env.apache_restart() == 0
+        assert env.apache_restart() == 0, f'{env.apachectl_stderr}'
         env.check_md([name, "www.testdomain.org", "mail.testdomain.org"], state=1,
                      ca="http://acme.test.org:4000/directory", protocol="ACME",
                      agreement="http://acme.test.org:4000/terms/v1")
@@ -114,7 +114,7 @@ class TestConf:
         MDConf(env, admin="admin@testdomain.org", text="""
             MDomain testdomain.org www.testdomain.org mail.testdomain.org
             """).install()
-        assert env.apache_restart() == 0
+        assert env.apache_restart() == 0, f'{env.apachectl_stderr}'
         name = "testdomain.org"
         env.check_md([name, "www.testdomain.org", "mail.testdomain.org"], state=1,
                      contacts=["mailto:admin@testdomain.org"])
@@ -126,7 +126,7 @@ class TestConf:
         MDConf(env, admin="admin@testdomain.org", text="""
             MDomain testdomain.org www.testdomain.org mail.testdomain.org
             """).install()
-        assert env.apache_restart() == 0
+        assert env.apache_restart() == 0, f'{env.apachectl_stderr}'
         env.check_md([name, "www.testdomain.org", "mail.testdomain.org"], state=1,
                      contacts=["mailto:admin@testdomain.org"])
 
@@ -148,7 +148,7 @@ class TestConf:
                 ServerAdmin mailto:admin@testdomain2.org
             </VirtualHost>
             """).install()
-        assert env.apache_restart() == 0
+        assert env.apache_restart() == 0, f'{env.apachectl_stderr}'
         name1 = "testdomain.org"
         name2 = "testdomain2.org"
         env.check_md([name1, "www." + name1, "mail." + name1], state=1, contacts=["mailto:admin@" + name1])
@@ -159,7 +159,7 @@ class TestConf:
         MDConf(env, text="""
             MDomain testdomain.org WWW.testdomain.org MAIL.testdomain.org
             """).install()
-        assert env.apache_restart() == 0
+        assert env.apache_restart() == 0, f'{env.apachectl_stderr}'
         env.check_md(["testdomain.org", "www.testdomain.org", "mail.testdomain.org"], state=1)
 
     # test case: default drive mode - auto
@@ -167,7 +167,7 @@ class TestConf:
         MDConf(env, text="""
             MDomain testdomain.org www.testdomain.org mail.testdomain.org
             """).install()
-        assert env.apache_restart() == 0
+        assert env.apache_restart() == 0, f'{env.apachectl_stderr}'
         assert env.a2md(["list"]).json['output'][0]['renew-mode'] == 1
 
     # test case: drive mode manual
@@ -176,7 +176,7 @@ class TestConf:
             MDRenewMode manual
             MDomain testdomain.org www.testdomain.org mail.testdomain.org
             """).install()
-        assert env.apache_restart() == 0
+        assert env.apache_restart() == 0, f'{env.apachectl_stderr}'
         assert env.a2md(["list"]).json['output'][0]['renew-mode'] == 0
 
     # test case: drive mode auto
@@ -185,7 +185,7 @@ class TestConf:
             MDRenewMode auto
             MDomain testdomain.org www.testdomain.org mail.testdomain.org
             """).install()
-        assert env.apache_restart() == 0
+        assert env.apache_restart() == 0, f'{env.apachectl_stderr}'
         assert env.a2md(["list"]).json['output'][0]['renew-mode'] == 1
 
     # test case: drive mode always
@@ -194,7 +194,7 @@ class TestConf:
             MDRenewMode always
             MDomain testdomain.org www.testdomain.org mail.testdomain.org
             """).install()
-        assert env.apache_restart() == 0
+        assert env.apache_restart() == 0, f'{env.apachectl_stderr}'
         assert env.a2md(["list"]).json['output'][0]['renew-mode'] == 2
 
     # test case: renew window - 14 days
@@ -203,7 +203,7 @@ class TestConf:
             MDRenewWindow 14d
             MDomain testdomain.org www.testdomain.org mail.testdomain.org
             """).install()
-        assert env.apache_restart() == 0
+        assert env.apache_restart() == 0, f'{env.apachectl_stderr}'
         assert env.a2md(["list"]).json['output'][0]['renew-window'] == '14d'
 
     # test case: renew window - 10 percent
@@ -212,7 +212,7 @@ class TestConf:
             MDRenewWindow 10%
             MDomain testdomain.org www.testdomain.org mail.testdomain.org
             """).install()
-        assert env.apache_restart() == 0
+        assert env.apache_restart() == 0, f'{env.apachectl_stderr}'
         assert env.a2md(["list"]).json['output'][0]['renew-window'] == '10%'
         
     # test case: ca challenge type - http-01
@@ -221,7 +221,7 @@ class TestConf:
             MDCAChallenges http-01
             MDomain testdomain.org www.testdomain.org mail.testdomain.org
             """).install()
-        assert env.apache_restart() == 0
+        assert env.apache_restart() == 0, f'{env.apachectl_stderr}'
         assert env.a2md(["list"]).json['output'][0]['ca']['challenges'] == ['http-01']
 
     # test case: ca challenge type - http-01
@@ -230,7 +230,7 @@ class TestConf:
             MDCAChallenges tls-alpn-01
             MDomain testdomain.org www.testdomain.org mail.testdomain.org
             """).install()
-        assert env.apache_restart() == 0
+        assert env.apache_restart() == 0, f'{env.apachectl_stderr}'
         assert env.a2md(["list"]).json['output'][0]['ca']['challenges'] == ['tls-alpn-01']
 
     # test case: ca challenge type - all
@@ -239,7 +239,7 @@ class TestConf:
             MDCAChallenges http-01 tls-alpn-01
             MDomain testdomain.org www.testdomain.org mail.testdomain.org
             """).install()
-        assert env.apache_restart() == 0
+        assert env.apache_restart() == 0, f'{env.apachectl_stderr}'
         assert env.a2md(["list"]).json['output'][0]['ca']['challenges'] == ['http-01', 'tls-alpn-01']
 
     # test case: automatically collect md names from vhost config
@@ -252,7 +252,7 @@ class TestConf:
             "testdomain.org", "test.testdomain.org", "mail.testdomain.org",
         ], with_ssl=True)
         conf.install()
-        assert env.apache_restart() == 0
+        assert env.apache_restart() == 0, f'{env.apachectl_stderr}'
         assert env.a2md(["list"]).json['output'][0]['domains'] == \
                ['testdomain.org', 'test.testdomain.org', 'mail.testdomain.org']
 
@@ -261,12 +261,12 @@ class TestConf:
         MDConf(env, text="""
             MDomain testdomain.org www.testdomain.org mail.testdomain.org
             """).install()
-        assert env.apache_restart() == 0
+        assert env.apache_restart() == 0, f'{env.apachectl_stderr}'
         MDConf(env, text="""
             MDRenewWindow 14d
             MDomain testdomain.org www.testdomain.org mail.testdomain.org
             """).install()
-        assert env.apache_restart() == 0
+        assert env.apache_restart() == 0, f'{env.apachectl_stderr}'
         stat = env.get_md_status("testdomain.org")
         assert stat['renew-window'] == '14d'
 
@@ -276,7 +276,7 @@ class TestConf:
             MDPrivateKeys RSA 2048
             MDomain testdomain.org www.testdomain.org mail.testdomain.org
             """).install()
-        assert env.apache_restart() == 0
+        assert env.apache_restart() == 0, f'{env.apachectl_stderr}'
         assert env.a2md(["list"]).json['output'][0]['privkey'] == {
             "type": "RSA",
             "bits": 2048
@@ -288,7 +288,7 @@ class TestConf:
             MDPrivateKeys RSA 4096
             MDomain testdomain.org www.testdomain.org mail.testdomain.org
             """).install()
-        assert env.apache_restart() == 0
+        assert env.apache_restart() == 0, f'{env.apachectl_stderr}'
         assert env.a2md(["list"]).json['output'][0]['privkey'] == {
             "type": "RSA",
             "bits": 4096
@@ -300,7 +300,7 @@ class TestConf:
             MDomain testdomain.org www.testdomain.org mail.testdomain.org
             MDRequireHttps temporary
             """).install()
-        assert env.apache_restart() == 0
+        assert env.apache_restart() == 0, f'{env.apachectl_stderr}'
         assert env.a2md(["list"]).json['output'][0]['require-https'] == "temporary"
 
     # test case: require OCSP stapling
@@ -309,7 +309,7 @@ class TestConf:
             MDomain testdomain.org www.testdomain.org mail.testdomain.org
             MDMustStaple on
             """).install()
-        assert env.apache_restart() == 0
+        assert env.apache_restart() == 0, f'{env.apachectl_stderr}'
         assert env.a2md(["list"]).json['output'][0]['must-staple'] is True
 
     # test case: remove managed domain from config
@@ -319,7 +319,7 @@ class TestConf:
         env.check_md(dns_list, state=1)
         conf = MDConf(env,)
         conf.install()
-        assert env.apache_restart() == 0
+        assert env.apache_restart() == 0, f'{env.apachectl_stderr}'
         # check: md stays in store
         env.check_md(dns_list, state=1)
 
@@ -331,7 +331,7 @@ class TestConf:
         MDConf(env, text="""
             MDomain testdomain.org www.testdomain.org mail.testdomain.org
             """).install()
-        assert env.apache_restart() == 0
+        assert env.apache_restart() == 0, f'{env.apachectl_stderr}'
         # check: DNS has been removed from md in store
         env.check_md(["testdomain.org", "www.testdomain.org", "mail.testdomain.org"], state=1)
 
@@ -343,7 +343,7 @@ class TestConf:
         MDConf(env, text="""
             MDomain testdomain.org www.testdomain.org mail.testdomain.org
             """).install()
-        assert env.apache_restart() == 0
+        assert env.apache_restart() == 0, f'{env.apachectl_stderr}'
         # check: md overwrite previous name and changes name
         env.check_md(["testdomain.org", "www.testdomain.org", "mail.testdomain.org"],
                      md="testdomain.org", state=1)
@@ -359,7 +359,7 @@ class TestConf:
         MDConf(env, text="""
             MDomain testdomain.org www.testdomain.org mail.testdomain.org
             """).install()
-        assert env.apache_restart() == 0
+        assert env.apache_restart() == 0, f'{env.apachectl_stderr}'
         # all mds stay in store
         env.check_md(dns_list1, state=1)
         env.check_md(dns_list2, state=1)
@@ -374,12 +374,12 @@ class TestConf:
 
             MDomain testdomain.org www.testdomain.org mail.testdomain.org
             """).install()
-        assert env.apache_restart() == 0
+        assert env.apache_restart() == 0, f'{env.apachectl_stderr}'
         # setup: sync with ca info removed
         MDConf(env, local_ca=False, text="""
             MDomain testdomain.org www.testdomain.org mail.testdomain.org
             """).install()
-        assert env.apache_restart() == 0
+        assert env.apache_restart() == 0, f'{env.apachectl_stderr}'
         env.check_md([name, "www.testdomain.org", "mail.testdomain.org"], state=1,
                      ca="https://acme-v02.api.letsencrypt.org/directory", protocol="ACME")
 
@@ -389,12 +389,12 @@ class TestConf:
         MDConf(env, admin="admin@testdomain.org", text="""
             MDomain testdomain.org www.testdomain.org mail.testdomain.org
             """).install()
-        assert env.apache_restart() == 0
+        assert env.apache_restart() == 0, f'{env.apachectl_stderr}'
         # setup: sync with admin info removed
         MDConf(env, admin="", text="""
             MDomain testdomain.org www.testdomain.org mail.testdomain.org
             """).install()
-        assert env.apache_restart() == 0
+        assert env.apache_restart() == 0, f'{env.apachectl_stderr}'
         # check: md stays the same with previous admin info
         env.check_md([name, "www.testdomain.org", "mail.testdomain.org"], state=1,
                      contacts=["mailto:admin@testdomain.org"])
@@ -405,12 +405,12 @@ class TestConf:
             MDRenewWindow 14d
             MDomain testdomain.org www.testdomain.org mail.testdomain.org
             """).install()
-        assert env.apache_restart() == 0
+        assert env.apache_restart() == 0, f'{env.apachectl_stderr}'
         assert env.a2md(["list"]).json['output'][0]['renew-window'] == '14d'
         MDConf(env, text="""
             MDomain testdomain.org www.testdomain.org mail.testdomain.org
             """).install()
-        assert env.apache_restart() == 0
+        assert env.apache_restart() == 0, f'{env.apachectl_stderr}'
         # check: renew window not set
         assert env.a2md(["list"]).json['output'][0]['renew-window'] == '33%'
 
@@ -425,13 +425,13 @@ class TestConf:
             MDRenewMode %s
             MDomain testdomain.org www.testdomain.org mail.testdomain.org
             """ % renew_mode).install()
-        assert env.apache_restart() == 0
+        assert env.apache_restart() == 0, f'{env.apachectl_stderr}'
         assert env.a2md(["list"]).json['output'][0]['renew-mode'] == exp_code
         #
         MDConf(env, text="""
             MDomain testdomain.org www.testdomain.org mail.testdomain.org
             """).install()
-        assert env.apache_restart() == 0
+        assert env.apache_restart() == 0, f'{env.apachectl_stderr}'
         assert env.a2md(["list"]).json['output'][0]['renew-mode'] == 1
 
     # test case: remove challenges from conf -> fallback to default (not set)
@@ -440,13 +440,13 @@ class TestConf:
             MDCAChallenges http-01
             MDomain testdomain.org www.testdomain.org mail.testdomain.org
             """).install()
-        assert env.apache_restart() == 0
+        assert env.apache_restart() == 0, f'{env.apachectl_stderr}'
         assert env.a2md(["list"]).json['output'][0]['ca']['challenges'] == ['http-01']
         #
         MDConf(env, text="""
             MDomain testdomain.org www.testdomain.org mail.testdomain.org
             """).install()
-        assert env.apache_restart() == 0
+        assert env.apache_restart() == 0, f'{env.apachectl_stderr}'
         assert 'challenges' not in env.a2md(["list"]).json['output'][0]['ca']
 
     # test case: specify RSA key
@@ -456,13 +456,13 @@ class TestConf:
             MDPrivateKeys RSA %s
             MDomain testdomain.org www.testdomain.org mail.testdomain.org
             """ % key_size).install()
-        assert env.apache_restart() == 0
+        assert env.apache_restart() == 0, f'{env.apachectl_stderr}'
         assert env.a2md(["list"]).json['output'][0]['privkey']['type'] == "RSA"
         #
         MDConf(env, text="""
             MDomain testdomain.org www.testdomain.org mail.testdomain.org
             """).install()
-        assert env.apache_restart() == 0
+        assert env.apache_restart() == 0, f'{env.apachectl_stderr}'
         assert "privkey" not in env.a2md(["list"]).json['output'][0]
 
     # test case: require HTTPS
@@ -474,14 +474,14 @@ class TestConf:
                 MDRequireHttps %s
             </MDomainSet>
             """ % mode).install()
-        assert env.apache_restart() == 0
+        assert env.apache_restart() == 0, f'{env.apachectl_stderr}'
         assert env.a2md(["list"]).json['output'][0]['require-https'] == mode, \
             "Unexpected HTTPS require mode in store. config: {}".format(mode)
         #
         MDConf(env, text="""
             MDomain testdomain.org www.testdomain.org mail.testdomain.org
             """).install()
-        assert env.apache_restart() == 0
+        assert env.apache_restart() == 0, f'{env.apachectl_stderr}'
         assert "require-https" not in env.a2md(["list"]).json['output'][0], \
             "HTTPS require still persisted in store. config: {}".format(mode)
 
@@ -491,13 +491,13 @@ class TestConf:
             MDomain testdomain.org www.testdomain.org mail.testdomain.org
             MDMustStaple on
             """).install()
-        assert env.apache_restart() == 0
+        assert env.apache_restart() == 0, f'{env.apachectl_stderr}'
         assert env.a2md(["list"]).json['output'][0]['must-staple'] is True
         #
         MDConf(env, text="""
             MDomain testdomain.org www.testdomain.org mail.testdomain.org
             """).install()
-        assert env.apache_restart() == 0
+        assert env.apache_restart() == 0, f'{env.apachectl_stderr}'
         assert env.a2md(["list"]).json['output'][0]['must-staple'] is False
 
     # test case: reorder DNS names in md definition
@@ -508,7 +508,7 @@ class TestConf:
         MDConf(env, text="""
             MDomain testdomain.org www.testdomain.org mail.testdomain.org
             """).install()
-        assert env.apache_restart() == 0
+        assert env.apache_restart() == 0, f'{env.apachectl_stderr}'
         # check: dns list changes
         env.check_md(["testdomain.org", "www.testdomain.org", "mail.testdomain.org"], state=1)
 
@@ -523,7 +523,7 @@ class TestConf:
             MDomain testdomain.org www.testdomain.org mail.testdomain.org
             MDomain testdomain2.org www.testdomain2.org mail.testdomain2.org
             """).install()
-        assert env.apache_restart() == 0
+        assert env.apache_restart() == 0, f'{env.apachectl_stderr}'
         env.check_md(["testdomain.org", "www.testdomain.org", "mail.testdomain.org"], state=1)
         env.check_md(["testdomain2.org", "www.testdomain2.org", "mail.testdomain2.org"], state=1)
 
@@ -537,7 +537,7 @@ class TestConf:
 
             MDomain testdomain.org www.testdomain.org mail.testdomain.org
             """).install()
-        assert env.apache_restart() == 0
+        assert env.apache_restart() == 0, f'{env.apachectl_stderr}'
         # setup: sync with changed ca info
         MDConf(env, local_ca=False, admin="webmaster@testdomain.org",
                   text="""
@@ -547,7 +547,7 @@ class TestConf:
 
             MDomain testdomain.org www.testdomain.org mail.testdomain.org
             """).install()
-        assert env.apache_restart() == 0
+        assert env.apache_restart() == 0, f'{env.apachectl_stderr}'
         # check: md stays the same with previous ca info
         env.check_md([name, "www.testdomain.org", "mail.testdomain.org"], state=1,
                      ca="http://somewhere.com:6666/directory", protocol="ACME",
@@ -559,7 +559,7 @@ class TestConf:
         MDConf(env, admin="admin@testdomain.org", text="""
             MDomain testdomain.org www.testdomain.org mail.testdomain.org
             """).install()
-        assert env.apache_restart() == 0
+        assert env.apache_restart() == 0, f'{env.apachectl_stderr}'
         # setup: sync with changed admin info
         MDConf(env, local_ca=False, admin="webmaster@testdomain.org", text="""
             MDCertificateAuthority http://somewhere.com:6666/directory
@@ -568,7 +568,7 @@ class TestConf:
 
             MDomain testdomain.org www.testdomain.org mail.testdomain.org
             """).install()
-        assert env.apache_restart() == 0
+        assert env.apache_restart() == 0, f'{env.apachectl_stderr}'
         # check: md stays the same with previous admin info
         env.check_md([name, "www.testdomain.org", "mail.testdomain.org"], state=1,
                      contacts=["mailto:webmaster@testdomain.org"])
@@ -579,21 +579,21 @@ class TestConf:
             MDRenewMode manual
             MDomain testdomain.org www.testdomain.org mail.testdomain.org
             """).install()
-        assert env.apache_restart() == 0
+        assert env.apache_restart() == 0, f'{env.apachectl_stderr}'
         assert env.a2md(["list"]).json['output'][0]['renew-mode'] == 0
         # test case: drive mode auto
         MDConf(env, text="""
             MDRenewMode auto
             MDomain testdomain.org www.testdomain.org mail.testdomain.org
             """).install()
-        assert env.apache_restart() == 0
+        assert env.apache_restart() == 0, f'{env.apachectl_stderr}'
         assert env.a2md(["list"]).json['output'][0]['renew-mode'] == 1
         # test case: drive mode always
         MDConf(env, text="""
             MDRenewMode always
             MDomain testdomain.org www.testdomain.org mail.testdomain.org
             """).install()
-        assert env.apache_restart() == 0
+        assert env.apache_restart() == 0, f'{env.apachectl_stderr}'
         assert env.a2md(["list"]).json['output'][0]['renew-mode'] == 2
 
     # test case: change config value for renew window, use various syntax alternatives
@@ -602,21 +602,21 @@ class TestConf:
             MDRenewWindow 14d
             MDomain testdomain.org www.testdomain.org mail.testdomain.org
             """).install()
-        assert env.apache_restart() == 0
+        assert env.apache_restart() == 0, f'{env.apachectl_stderr}'
         md = env.a2md(["list"]).json['output'][0]
         assert md['renew-window'] == '14d'
         MDConf(env, text="""
             MDRenewWindow 10
             MDomain testdomain.org www.testdomain.org mail.testdomain.org
             """).install()
-        assert env.apache_restart() == 0
+        assert env.apache_restart() == 0, f'{env.apachectl_stderr}'
         md = env.a2md(["list"]).json['output'][0]
         assert md['renew-window'] == '10d'
         MDConf(env, text="""
             MDRenewWindow 10%
             MDomain testdomain.org www.testdomain.org mail.testdomain.org
             """).install()
-        assert env.apache_restart() == 0
+        assert env.apache_restart() == 0, f'{env.apachectl_stderr}'
         md = env.a2md(["list"]).json['output'][0]
         assert md['renew-window'] == '10%'
 
@@ -626,21 +626,21 @@ class TestConf:
             MDCAChallenges http-01
             MDomain testdomain.org www.testdomain.org mail.testdomain.org
             """).install()
-        assert env.apache_restart() == 0
+        assert env.apache_restart() == 0, f'{env.apachectl_stderr}'
         assert env.a2md(["list"]).json['output'][0]['ca']['challenges'] == ['http-01']
         # test case: drive mode auto
         MDConf(env, text="""
             MDCAChallenges tls-alpn-01
             MDomain testdomain.org www.testdomain.org mail.testdomain.org
             """).install()
-        assert env.apache_restart() == 0
+        assert env.apache_restart() == 0, f'{env.apachectl_stderr}'
         assert env.a2md(["list"]).json['output'][0]['ca']['challenges'] == ['tls-alpn-01']
         # test case: drive mode always
         MDConf(env, text="""
             MDCAChallenges http-01 tls-alpn-01
             MDomain testdomain.org www.testdomain.org mail.testdomain.org
             """).install()
-        assert env.apache_restart() == 0
+        assert env.apache_restart() == 0, f'{env.apachectl_stderr}'
         assert env.a2md(["list"]).json['output'][0]['ca']['challenges'] == ['http-01', 'tls-alpn-01']
 
     # test case:  RSA key length: 4096 -> 2048 -> 4096
@@ -649,7 +649,7 @@ class TestConf:
             MDPrivateKeys RSA 4096
             MDomain testdomain.org www.testdomain.org mail.testdomain.org
             """).install()
-        assert env.apache_restart() == 0
+        assert env.apache_restart() == 0, f'{env.apachectl_stderr}'
         assert env.a2md(["list"]).json['output'][0]['privkey'] == {
             "type": "RSA",
             "bits": 4096
@@ -658,7 +658,7 @@ class TestConf:
             MDPrivateKeys RSA 2048
             MDomain testdomain.org www.testdomain.org mail.testdomain.org
             """).install()
-        assert env.apache_restart() == 0
+        assert env.apache_restart() == 0, f'{env.apachectl_stderr}'
         assert env.a2md(["list"]).json['output'][0]['privkey'] == {
             "type": "RSA",
             "bits": 2048
@@ -667,7 +667,7 @@ class TestConf:
             MDPrivateKeys RSA 4096
             MDomain testdomain.org www.testdomain.org mail.testdomain.org
             """).install()
-        assert env.apache_restart() == 0
+        assert env.apache_restart() == 0, f'{env.apachectl_stderr}'
         assert env.a2md(["list"]).json['output'][0]['privkey'] == {
             "type": "RSA",
             "bits": 4096
@@ -679,14 +679,14 @@ class TestConf:
         MDConf(env, text="""
             MDomain testdomain.org www.testdomain.org mail.testdomain.org
             """).install()
-        assert env.apache_restart() == 0
+        assert env.apache_restart() == 0, f'{env.apachectl_stderr}'
         assert "require-https" not in env.a2md(["list"]).json['output'][0]
         # test case: temporary redirect
         MDConf(env, text="""
             MDomain testdomain.org www.testdomain.org mail.testdomain.org
             MDRequireHttps temporary
             """).install()
-        assert env.apache_restart() == 0
+        assert env.apache_restart() == 0, f'{env.apachectl_stderr}'
         assert env.a2md(["list"]).json['output'][0]['require-https'] == "temporary"
         # test case: permanent redirect
         MDConf(env, text="""
@@ -695,7 +695,7 @@ class TestConf:
                 MDRequireHttps permanent
             </MDomainSet>
             """).install()
-        assert env.apache_restart() == 0
+        assert env.apache_restart() == 0, f'{env.apachectl_stderr}'
         assert env.a2md(["list"]).json['output'][0]['require-https'] == "permanent"
 
     # test case: change OCSP stapling settings on existing md
@@ -704,21 +704,21 @@ class TestConf:
         MDConf(env, text="""
             MDomain testdomain.org www.testdomain.org mail.testdomain.org
             """).install()
-        assert env.apache_restart() == 0
+        assert env.apache_restart() == 0, f'{env.apachectl_stderr}'
         assert env.a2md(["list"]).json['output'][0]['must-staple'] is False
         # test case: OCSP stapling on
         MDConf(env, text="""
             MDomain testdomain.org www.testdomain.org mail.testdomain.org
             MDMustStaple on
             """).install()
-        assert env.apache_restart() == 0
+        assert env.apache_restart() == 0, f'{env.apachectl_stderr}'
         assert env.a2md(["list"]).json['output'][0]['must-staple'] is True
         # test case: OCSP stapling off
         MDConf(env, text="""
             MDomain testdomain.org www.testdomain.org mail.testdomain.org
             MDMustStaple off
             """).install()
-        assert env.apache_restart() == 0
+        assert env.apache_restart() == 0, f'{env.apachectl_stderr}'
         assert env.a2md(["list"]).json['output'][0]['must-staple'] is False
 
     # test case: change renew window parameter
@@ -735,7 +735,7 @@ class TestConf:
         conf.end_md()
         conf.add_vhost(domains=domain)
         conf.install()
-        assert env.apache_restart() == 0
+        assert env.apache_restart() == 0, f'{env.apachectl_stderr}'
         stat = env.get_md_status(domain)
         assert stat["renew-window"] == window
 
@@ -748,7 +748,7 @@ class TestConf:
         assert env.a2md(["update", name, "contacts", "admin@" + name]).exit_code == 0
         assert env.a2md(["update", name, "agreement", env.acme_tos]).exit_code == 0
         MDConf(env).install()
-        assert env.apache_restart() == 0
+        assert env.apache_restart() == 0, f'{env.apachectl_stderr}'
 
         # setup: drive it
         r = env.a2md(["-v", "drive", name])
@@ -771,7 +771,7 @@ class TestConf:
         assert env.a2md(["add", name]).exit_code == 0
         assert env.a2md(["update", name, "contacts", "admin@" + name]).exit_code == 0
         assert env.a2md(["update", name, "agreement", env.acme_tos]).exit_code == 0
-        assert env.apache_restart() == 0
+        assert env.apache_restart() == 0, f'{env.apachectl_stderr}'
         # setup: drive it
         assert env.a2md(["drive", name]).exit_code == 0
         assert env.a2md(["list", name]).json['output'][0]['state'] == env.MD_S_COMPLETE
@@ -786,7 +786,7 @@ class TestConf:
             MDStoreDir md-other
             MDomain testdomain.org www.testdomain.org mail.testdomain.org
             """).install()
-        assert env.apache_restart() == 0
+        assert env.apache_restart() == 0, f'{env.apachectl_stderr}'
         assert env.a2md(["list"]).json['output'] == []
         env.set_store_dir("md-other")
         env.check_md(["testdomain.org", "www.testdomain.org", "mail.testdomain.org"], state=1)
@@ -802,13 +802,13 @@ class TestConf:
         conf.end_md()
         conf.add_vhost(domains=[domain])
         conf.install()
-        assert env.apache_restart() == 0
+        assert env.apache_restart() == 0, f'{env.apachectl_stderr}'
         # add a file at top level
         assert env.await_completion([domain])
         fpath = os.path.join(env.store_domains(), "wrong.com")
         with open(fpath, 'w') as fd:
             fd.write("this does not belong here\n")
-        assert env.apache_restart() == 0
+        assert env.apache_restart() == 0, f'{env.apachectl_stderr}'
 
     # test case: add external account binding
     def test_md_310_601(self, env):
@@ -821,7 +821,7 @@ class TestConf:
         conf.end_md()
         conf.add_vhost(domains=domain)
         conf.install()
-        assert env.apache_restart() == 0
+        assert env.apache_restart() == 0, f'{env.apachectl_stderr}'
         stat = env.get_md_status(domain)
         assert stat["eab"] == {'kid': 'k123', 'hmac': '***'}
         # eab inherited
@@ -832,7 +832,7 @@ class TestConf:
         conf.end_md()
         conf.add_vhost(domains=domain)
         conf.install()
-        assert env.apache_restart() == 0
+        assert env.apache_restart() == 0, f'{env.apachectl_stderr}'
         stat = env.get_md_status(domain)
         assert stat["eab"] == {'kid': 'k456', 'hmac': '***'}
         # override eab inherited
@@ -844,7 +844,7 @@ class TestConf:
         conf.end_md()
         conf.add_vhost(domains=domain)
         conf.install()
-        assert env.apache_restart() == 0
+        assert env.apache_restart() == 0, f'{env.apachectl_stderr}'
         stat = env.get_md_status(domain)
         assert "eab" not in stat
 

--- a/test/modules/md/test_602_roundtrip.py
+++ b/test/modules/md/test_602_roundtrip.py
@@ -39,16 +39,16 @@ class TestRoundtripv2:
         conf.add_md(domains)
         conf.install()
         # - restart, check that md is in store
-        assert env.apache_restart() == 0
+        assert env.apache_restart() == 0, f'{env.apachectl_stderr}'
         env.check_md(domains)
         # - drive
         assert env.a2md(["-v", "drive", domain]).exit_code == 0
-        assert env.apache_restart() == 0
+        assert env.apache_restart() == 0, f'{env.apachectl_stderr}'
         env.check_md_complete(domain)
         # - append vhost to config
         conf.add_vhost(domains)
         conf.install()
-        assert env.apache_restart() == 0
+        assert env.apache_restart() == 0, f'{env.apachectl_stderr}'
         # check: SSL is running OK
         cert = env.get_cert(domain)
         assert domain in cert.get_san_list()
@@ -71,14 +71,14 @@ class TestRoundtripv2:
         conf.install()
 
         # - restart, check that md is in store
-        assert env.apache_restart() == 0
+        assert env.apache_restart() == 0, f'{env.apachectl_stderr}'
         env.check_md(domains_a)
         env.check_md(domains_b)
 
         # - drive
         assert env.a2md(["drive", domain_a]).exit_code == 0
         assert env.a2md(["drive", domain_b]).exit_code == 0
-        assert env.apache_restart() == 0
+        assert env.apache_restart() == 0, f'{env.apachectl_stderr}'
         env.check_md_complete(domain_a)
         env.check_md_complete(domain_b)
 
@@ -88,7 +88,7 @@ class TestRoundtripv2:
         conf.install()
 
         # check: SSL is running OK
-        assert env.apache_restart() == 0
+        assert env.apache_restart() == 0, f'{env.apachectl_stderr}'
         cert_a = env.get_cert(domain_a)
         assert domains_a == cert_a.get_san_list()
         cert_b = env.get_cert(domain_b)
@@ -108,12 +108,12 @@ class TestRoundtripv2:
         conf.install()
         
         # - restart, check that md is in store
-        assert env.apache_restart() == 0
+        assert env.apache_restart() == 0, f'{env.apachectl_stderr}'
         env.check_md(domains)
 
         # - drive
         assert env.a2md(["drive", domain]).exit_code == 0
-        assert env.apache_restart() == 0
+        assert env.apache_restart() == 0, f'{env.apachectl_stderr}'
         env.check_md_complete(domain)
 
         # - append vhost to config
@@ -126,7 +126,7 @@ class TestRoundtripv2:
         self._write_res_file(os.path.join(env.server_docs_dir, "b"), "name.txt", name_b)
 
         # check: SSL is running OK
-        assert env.apache_restart() == 0
+        assert env.apache_restart() == 0, f'{env.apachectl_stderr}'
         cert_a = env.get_cert(name_a)
         assert name_a in cert_a.get_san_list()
         cert_b = env.get_cert(name_b)

--- a/test/modules/md/test_702_auto.py
+++ b/test/modules/md/test_702_auto.py
@@ -21,7 +21,7 @@ class TestAutov2:
         env.check_acme()
         env.clear_store()
         MDConf(env).install()
-        assert env.apache_restart() == 0
+        assert env.apache_restart() == 0, f'{env.apachectl_stderr}'
 
     @pytest.fixture(autouse=True, scope='function')
     def _method_scope(self, env, request):
@@ -44,7 +44,7 @@ class TestAutov2:
         conf.install()
         #
         # restart, check that MD is synched to store
-        assert env.apache_restart() == 0
+        assert env.apache_restart() == 0, f'{env.apachectl_stderr}'
         env.check_md(domains)
         stat = env.get_md_status(domain)
         assert stat["watched"] == 0
@@ -52,7 +52,7 @@ class TestAutov2:
         # add vhost for MD, restart should drive it
         conf.add_vhost(domains)
         conf.install()
-        assert env.apache_restart() == 0
+        assert env.apache_restart() == 0, f'{env.apachectl_stderr}'
         assert env.await_completion([domain])
         env.check_md_complete(domain)
         stat = env.get_md_status(domain)
@@ -89,7 +89,7 @@ class TestAutov2:
         conf.install()
         #
         # restart, check that md is in store
-        assert env.apache_restart() == 0
+        assert env.apache_restart() == 0, f'{env.apachectl_stderr}'
         env.check_md(domains_a)
         env.check_md(domains_b)
         #
@@ -106,7 +106,7 @@ class TestAutov2:
         assert status['state-descr'] == "certificate(rsa) is missing"
 
         # restart and activate
-        assert env.apache_restart() == 0
+        assert env.apache_restart() == 0, f'{env.apachectl_stderr}'
         # check: SSL is running OK
         cert_a = env.get_cert(domain_a)
         assert domains_a == cert_a.get_san_list()
@@ -136,7 +136,7 @@ class TestAutov2:
         self._write_res_file(os.path.join(env.server_docs_dir, "b"), "name.txt", name_b)
         #
         # restart (-> drive), check that MD was synched and completes
-        assert env.apache_restart() == 0
+        assert env.apache_restart() == 0, f'{env.apachectl_stderr}'
         env.check_md(domains)
         assert env.await_completion([domain])
         md = env.check_md_complete(domain)
@@ -170,7 +170,7 @@ class TestAutov2:
         conf.install()
         #
         # restart (-> drive), check that MD was synched and completes
-        assert env.apache_restart() == 0
+        assert env.apache_restart() == 0, f'{env.apachectl_stderr}'
         env.check_md(domains)
         assert env.await_completion([domain])
         env.check_md_complete(domain)
@@ -196,7 +196,7 @@ class TestAutov2:
         self._write_res_file(os.path.join(env.server_docs_dir, "a"), "name.txt", name_a)
         #
         # restart, check that md is in store
-        assert env.apache_restart() == 0
+        assert env.apache_restart() == 0, f'{env.apachectl_stderr}'
         env.check_md(domains)
         #        
         # check: that request to domains give 503 Service Unavailable
@@ -227,7 +227,7 @@ class TestAutov2:
         self._write_res_file(os.path.join(env.server_docs_dir, "a"), "name.txt", name_a)
         #
         # restart, check that md is in store
-        assert env.apache_restart() == 0
+        assert env.apache_restart() == 0, f'{env.apachectl_stderr}'
         env.check_md(domains)
         # await drive completion
         md = env.await_error(domain)
@@ -262,7 +262,7 @@ class TestAutov2:
         conf.install()
         #
         # - restart (-> drive)
-        assert env.apache_restart() == 0
+        assert env.apache_restart() == 0, f'{env.apachectl_stderr}'
         # await drive completion
         md = env.await_error(domain)
         assert md
@@ -291,9 +291,9 @@ class TestAutov2:
         conf.install()
         #
         # - restart (-> drive), check that md is in store
-        assert env.apache_restart() == 0
+        assert env.apache_restart() == 0, f'{env.apachectl_stderr}'
         assert env.await_completion([domain])
-        assert env.apache_restart() == 0
+        assert env.apache_restart() == 0, f'{env.apachectl_stderr}'
         env.check_md_complete(domain)
 
     # Force cert renewal due to critical remaining valid duration
@@ -311,7 +311,7 @@ class TestAutov2:
         conf.install()
         #
         # restart (-> drive), check that md+cert is in store, TLS is up
-        assert env.apache_restart() == 0
+        assert env.apache_restart() == 0, f'{env.apachectl_stderr}'
         assert env.await_completion([domain])
         env.check_md_complete(domain)
         cert1 = MDCertUtil(env.store_domain_file(domain, 'pubcert.pem'))
@@ -327,7 +327,7 @@ class TestAutov2:
         creds.save_cert_pem(env.store_domain_file(domain, 'pubcert.pem'))
         creds.save_pkey_pem(env.store_domain_file(domain, 'privkey.pem'))
         assert creds.certificate.serial_number == 7029
-        assert env.apache_restart() == 0
+        assert env.apache_restart() == 0, f'{env.apachectl_stderr}'
         stat = env.get_certificate_status(domain)
         assert creds.certificate.serial_number == int(stat['rsa']['serial'], 16)
         #
@@ -348,7 +348,7 @@ class TestAutov2:
         conf.add_md(domains)
         conf.add_vhost(domains)
         conf.install()
-        assert env.apache_restart() == 0
+        assert env.apache_restart() == 0, f'{env.apachectl_stderr}'
         md = env.await_error(domain)
         assert md["renewal"]["errors"] > 0
         #
@@ -360,7 +360,7 @@ class TestAutov2:
         conf.add_md(domains)
         conf.add_vhost(domains)
         conf.install()
-        assert env.apache_restart() == 0
+        assert env.apache_restart() == 0, f'{env.apachectl_stderr}'
         env.check_md(domains)
         assert env.await_completion([domain])
         #
@@ -386,7 +386,7 @@ class TestAutov2:
         conf.add_md(domains)
         conf.add_vhost(domains)
         conf.install()
-        assert env.apache_restart() == 0
+        assert env.apache_restart() == 0, f'{env.apachectl_stderr}'
         md = env.await_error(domain)
         assert md["renewal"]["errors"] > 0
         #
@@ -399,7 +399,7 @@ class TestAutov2:
         conf.add_md(domains)
         conf.add_vhost(domains)
         conf.install()
-        assert env.apache_restart() == 0
+        assert env.apache_restart() == 0, f'{env.apachectl_stderr}'
         env.check_md(domains)
         assert env.await_completion([domain])
         #
@@ -431,7 +431,7 @@ class TestAutov2:
         conf.install()
         #
         # restart (-> drive), check that MD was synched and completes
-        assert env.apache_restart() == 0
+        assert env.apache_restart() == 0, f'{env.apachectl_stderr}'
         env.check_md(domains)
         assert env.await_completion([name_x])
         env.check_md_complete(name_x)
@@ -451,7 +451,7 @@ class TestAutov2:
         conf.add_vhost(name_b)
         conf.install()
         # restart, check that host still works and kept the cert
-        assert env.apache_restart() == 0
+        assert env.apache_restart() == 0, f'{env.apachectl_stderr}'
         env.check_md(new_list)
         status = env.get_certificate_status(name_a)
         assert cert_a.same_serial_as(status['rsa']['serial'])
@@ -475,7 +475,7 @@ class TestAutov2:
         conf.install()
         #
         # restart (-> drive), check that MD was synched and completes
-        assert env.apache_restart() == 0
+        assert env.apache_restart() == 0, f'{env.apachectl_stderr}'
         env.check_md(domains)
         assert env.await_completion([name_x])
         env.check_md_complete(name_x)
@@ -495,7 +495,7 @@ class TestAutov2:
         conf.add_vhost(name_b)
         conf.install()
         # restart, check that host still works and have new cert
-        assert env.apache_restart() == 0
+        assert env.apache_restart() == 0, f'{env.apachectl_stderr}'
         env.check_md(new_list)
         assert env.await_completion([name_a])
         #
@@ -520,7 +520,7 @@ class TestAutov2:
         conf.install()
         #
         # restart (-> drive), check that MD was synched and completes
-        assert env.apache_restart() == 0
+        assert env.apache_restart() == 0, f'{env.apachectl_stderr}'
         env.check_md([name1])
         env.check_md([name2])
         assert env.await_completion([name1, name2])
@@ -538,7 +538,7 @@ class TestAutov2:
         conf.add_md([name1])
         conf.add_vhost([name1, name2])
         conf.install()
-        assert env.apache_restart() == 0
+        assert env.apache_restart() == 0, f'{env.apachectl_stderr}'
         env.check_md([name1, name2])
         assert env.await_completion([name1])
         #
@@ -563,7 +563,7 @@ class TestAutov2:
         conf.install()
         #
         # restart (-> drive), check that MD was synched and completes
-        assert env.apache_restart() == 0
+        assert env.apache_restart() == 0, f'{env.apachectl_stderr}'
         env.check_md(domains1)
         assert env.await_completion([name_x])
         env.check_md_complete(name_x)
@@ -576,7 +576,7 @@ class TestAutov2:
         conf.add_vhost(domains=domains2)
         conf.install()
         # restart, check that host still works and kept the cert
-        assert env.apache_restart() == 0
+        assert env.apache_restart() == 0, f'{env.apachectl_stderr}'
         status = env.get_certificate_status(name_a)
         assert cert_x.same_serial_as(status['rsa']['serial'])
 
@@ -597,7 +597,7 @@ class TestAutov2:
         conf.install()
         #
         # restart (-> drive), check that MD was synched and completes
-        assert env.apache_restart() == 0
+        assert env.apache_restart() == 0, f'{env.apachectl_stderr}'
         env.check_md(domains)
         # check that acme-tls/1 is available for all domains
         stat = env.get_md_status(domain)
@@ -625,7 +625,7 @@ class TestAutov2:
         #
         # restart (-> drive), check that MD job shows errors 
         # and that missing proto is detected
-        assert env.apache_restart() == 0
+        assert env.apache_restart() == 0, f'{env.apachectl_stderr}'
         env.check_md(domains)
         # check that acme-tls/1 is available for none of the domains
         stat = env.get_md_status(domain)
@@ -645,7 +645,7 @@ class TestAutov2:
         conf.add_md(dns_list)
         conf.add_vhost(dns_list)
         conf.install()
-        assert env.apache_restart() == 0
+        assert env.apache_restart() == 0, f'{env.apachectl_stderr}'
         assert env.await_completion([domain])
 
     # test case: test "tls-alpn-01" without enabling 'acme-tls/1' challenge protocol
@@ -666,7 +666,7 @@ class TestAutov2:
         #
         # restart (-> drive), check that MD job shows errors
         # and that missing proto is detected
-        assert env.apache_restart() == 0
+        assert env.apache_restart() == 0, f'{env.apachectl_stderr}'
         env.check_md(domains)
         # check that acme-tls/1 is available for none of the domains
         stat = env.get_md_status(domain)
@@ -694,7 +694,7 @@ class TestAutov2:
         conf.install()
         #
         # restart (-> drive), check that MD was synched and completes
-        assert env.apache_restart() == 0
+        assert env.apache_restart() == 0, f'{env.apachectl_stderr}'
         env.check_md(md_domains)
         assert env.await_completion([domain])
         env.check_md_complete(domain)
@@ -714,7 +714,7 @@ class TestAutov2:
             """)
         conf.add_md([domain])
         conf.install()
-        assert env.apache_restart() == 0
+        assert env.apache_restart() == 0, f'{env.apachectl_stderr}'
         assert env.await_completion([domain])
 
     # Make a setup using the base server without http:, will fail.
@@ -728,7 +728,7 @@ class TestAutov2:
             """)
         conf.add_md([domain])
         conf.install()
-        assert env.apache_restart() == 0
+        assert env.apache_restart() == 0, f'{env.apachectl_stderr}'
         assert env.await_error(domain)
         #
         env.httpd_error_log.ignore_recent(
@@ -759,7 +759,7 @@ class TestAutov2:
         ])
         conf.add_md([domain])
         conf.install()
-        assert env.apache_restart() == 0
+        assert env.apache_restart() == 0, f'{env.apachectl_stderr}'
         stat = env.get_md_status(domain, via_domain=env.http_addr, use_https=False)
         assert stat["proto"]["acme-tls/1"] == [domain]
         assert env.await_completion([domain], via_domain=env.http_addr, use_https=False)
@@ -786,7 +786,7 @@ class TestAutov2:
         conf.add_md(domains)
         conf.add_vhost(domains)
         conf.install()
-        assert env.apache_restart() == 0
+        assert env.apache_restart() == 0, f'{env.apachectl_stderr}'
         env.check_md(domains)
         assert env.await_error(long_domain)
         # add a short domain to the SAN list, the CA should now use that one
@@ -800,7 +800,7 @@ class TestAutov2:
         conf.add_md(domains)
         conf.add_vhost(domains)
         conf.install()
-        assert env.apache_restart() == 0
+        assert env.apache_restart() == 0, f'{env.apachectl_stderr}'
         assert env.await_completion([long_domain])
         env.check_md_complete(long_domain)
         #
@@ -823,7 +823,7 @@ class TestAutov2:
         conf.install()
         #
         # restart (-> drive), check that MD was synched and completes
-        assert env.apache_restart() == 0
+        assert env.apache_restart() == 0, f'{env.apachectl_stderr}'
         assert env.await_completion(domains)
         env.check_md_complete(domains[0])
 
@@ -842,7 +842,7 @@ class TestAutov2:
         conf.install()
         #
         # restart (-> drive), check that MD was synched and completes
-        assert env.apache_restart() == 0
+        assert env.apache_restart() == 0, f'{env.apachectl_stderr}'
         assert env.await_completion(domains)
         env.check_md_complete(domains[0])
 

--- a/test/modules/md/test_720_wildcard.py
+++ b/test/modules/md/test_720_wildcard.py
@@ -18,7 +18,7 @@ class TestWildcard:
         env.check_acme()
         env.clear_store()
         MDConf(env).install()
-        assert env.apache_restart() == 0
+        assert env.apache_restart() == 0, f'{env.apachectl_stderr}'
 
     @pytest.fixture(autouse=True, scope='function')
     def _method_scope(self, env, request):
@@ -37,7 +37,7 @@ class TestWildcard:
         conf.install()
 
         # restart, check that md is in store
-        assert env.apache_restart() == 0
+        assert env.apache_restart() == 0, f'{env.apachectl_stderr}'
         env.check_md(domains)
         # await drive completion
         md = env.await_error(domain)
@@ -69,7 +69,7 @@ class TestWildcard:
         conf.install()
 
         # restart, check that md is in store
-        assert env.apache_restart() == 0
+        assert env.apache_restart() == 0, f'{env.apachectl_stderr}'
         env.check_md(domains)
         # await drive completion
         md = env.await_error(domain)
@@ -100,7 +100,7 @@ class TestWildcard:
         conf.install()
 
         # restart, check that md is in store
-        assert env.apache_restart() == 0
+        assert env.apache_restart() == 0, f'{env.apachectl_stderr}'
         env.check_md(domains)
         # await drive completion
         assert env.await_completion([domain])
@@ -125,7 +125,7 @@ class TestWildcard:
         conf.install()
 
         # restart, check that md is in store
-        assert env.apache_restart() == 0
+        assert env.apache_restart() == 0, f'{env.apachectl_stderr}'
         env.check_md(domains)
         # await drive completion
         md = env.await_error(domain)
@@ -156,7 +156,7 @@ class TestWildcard:
         conf.install()
 
         # restart, check that md is in store
-        assert env.apache_restart() == 0
+        assert env.apache_restart() == 0, f'{env.apachectl_stderr}'
         env.check_md(domains)
         # await drive completion
         assert env.await_completion([domain])
@@ -183,7 +183,7 @@ class TestWildcard:
         conf.install()
 
         # restart, check that md is in store
-        assert env.apache_restart() == 0
+        assert env.apache_restart() == 0, f'{env.apachectl_stderr}'
         env.check_md(domains)
         # await drive completion
         assert env.await_completion([domain])
@@ -211,7 +211,7 @@ class TestWildcard:
         conf.install()
 
         # restart, check that md is in store
-        assert env.apache_restart() == 0
+        assert env.apache_restart() == 0, f'{env.apachectl_stderr}'
         env.check_md(domains)
         # await drive completion
         assert env.await_completion([domain])
@@ -238,7 +238,7 @@ class TestWildcard:
         conf.install()
 
         # restart, check that md is in store
-        assert env.apache_restart() == 0
+        assert env.apache_restart() == 0, f'{env.apachectl_stderr}'
         env.check_md(domains)
         # await drive completion
         assert env.await_completion([wwwdomain])
@@ -270,7 +270,7 @@ class TestWildcard:
             fd.write(content)
 
         # restart, check that md is in store
-        assert env.apache_restart() == 0
+        assert env.apache_restart() == 0, f'{env.apachectl_stderr}'
         env.check_md(domains)
         # await drive completion
         assert env.await_completion([domain], restart=False)
@@ -278,5 +278,5 @@ class TestWildcard:
         r = env.curl_get(f"http://{domain}:{env.http_port}/.well-known/acme-challenge/123456")
         assert r.response['status'] == 200
         assert r.response['body'] == content
-        assert env.apache_restart() == 0
+        assert env.apache_restart() == 0, f'{env.apachectl_stderr}'
         env.check_md_complete(domain)

--- a/test/modules/md/test_730_static.py
+++ b/test/modules/md/test_730_static.py
@@ -19,7 +19,7 @@ class TestStatic:
         env.check_acme()
         env.clear_store()
         MDConf(env).install()
-        assert env.apache_restart() == 0
+        assert env.apache_restart() == 0, f'{env.apachectl_stderr}'
 
     @pytest.fixture(autouse=True, scope='function')
     def _method_scope(self, env, request):
@@ -48,7 +48,7 @@ class TestStatic:
         conf.end_md()
         conf.add_vhost(domain)
         conf.install()
-        assert env.apache_restart() == 0
+        assert env.apache_restart() == 0, f'{env.apachectl_stderr}'
         
         # check if the domain uses it, it appears in our stats and renewal is off
         cert = env.get_cert(domain)
@@ -83,7 +83,7 @@ class TestStatic:
         conf.end_md()
         conf.add_vhost(domain)
         conf.install()
-        assert env.apache_restart() == 0
+        assert env.apache_restart() == 0, f'{env.apachectl_stderr}'
         # this should enforce a renewal
         stat = env.get_md_status(domain)
         assert stat['renew'] is True, stat

--- a/test/modules/md/test_740_acme_errors.py
+++ b/test/modules/md/test_740_acme_errors.py
@@ -16,7 +16,7 @@ class TestAcmeErrors:
         env.check_acme()
         env.clear_store()
         MDConf(env).install()
-        assert env.apache_restart() == 0
+        assert env.apache_restart() == 0, f'{env.apachectl_stderr}'
 
     @pytest.fixture(autouse=True, scope='function')
     def _method_scope(self, env, request):
@@ -33,7 +33,7 @@ class TestAcmeErrors:
         conf.add_md(domains)
         conf.add_vhost(domains)
         conf.install()
-        assert env.apache_restart() == 0
+        assert env.apache_restart() == 0, f'{env.apachectl_stderr}'
         md = env.await_error(domain)
         assert md
         assert md['renewal']['errors'] > 0
@@ -65,7 +65,7 @@ class TestAcmeErrors:
         conf.add_md(domains)
         conf.add_vhost(domains)
         conf.install()
-        assert env.apache_restart() == 0
+        assert env.apache_restart() == 0, f'{env.apachectl_stderr}'
         md = env.await_error(domain)
         assert md
         assert md['renewal']['errors'] > 0

--- a/test/modules/md/test_741_setup_errors.py
+++ b/test/modules/md/test_741_setup_errors.py
@@ -18,7 +18,7 @@ class TestSetupErrors:
         env.check_acme()
         env.clear_store()
         MDConf(env).install()
-        assert env.apache_restart() == 0
+        assert env.apache_restart() == 0, f'{env.apachectl_stderr}'
 
     @pytest.fixture(autouse=True, scope='function')
     def _method_scope(self, env, request):
@@ -42,7 +42,7 @@ class TestSetupErrors:
         conf.add_md(domains)
         conf.add_vhost(domains)
         conf.install()
-        assert env.apache_restart() == 0
+        assert env.apache_restart() == 0, f'{env.apachectl_stderr}'
         md = env.await_error(domain, errors=2, timeout=10)
         assert md
         assert md['renewal']['errors'] > 0
@@ -65,13 +65,13 @@ class TestSetupErrors:
         conf.add_md(domains)
         conf.add_vhost(domains)
         conf.install()
-        assert env.apache_restart() == 0
+        assert env.apache_restart() == 0, f'{env.apachectl_stderr}'
         env.check_md(domains)
         assert env.await_completion([domain], restart=False)
         staged_md_path = env.store_staged_file(domain, 'md.json')
         with open(staged_md_path, 'w') as fd:
             fd.write('garbage\n')
-        assert env.apache_restart() == 0
+        assert env.apache_restart() == 0, f'{env.apachectl_stderr}'
         assert env.await_completion([domain])
         env.check_md_complete(domain)
         env.httpd_error_log.ignore_recent(

--- a/test/modules/md/test_750_eab.py
+++ b/test/modules/md/test_750_eab.py
@@ -18,7 +18,7 @@ class TestEab:
         env.check_acme()
         env.clear_store()
         MDConf(env).install()
-        assert env.apache_restart() == 0
+        assert env.apache_restart() == 0, f'{env.apachectl_stderr}'
 
     @pytest.fixture(autouse=True, scope='function')
     def _method_scope(self, env, request):
@@ -33,7 +33,7 @@ class TestEab:
         conf.add_md(domains)
         conf.add_vhost(domains=domains)
         conf.install()
-        assert env.apache_restart() == 0
+        assert env.apache_restart() == 0, f'{env.apachectl_stderr}'
         md = env.await_error(domain)
         assert md['renewal']['errors'] > 0
         assert md['renewal']['last']['problem'] == 'urn:ietf:params:acme:error:externalAccountRequired'
@@ -56,7 +56,7 @@ class TestEab:
         conf.add_md(domains)
         conf.add_vhost(domains=domains)
         conf.install()
-        assert env.apache_restart() == 0
+        assert env.apache_restart() == 0, f'{env.apachectl_stderr}'
         md = env.await_error(domain)
         assert md['renewal']['errors'] > 0
         assert md['renewal']['last']['problem'] == 'apache:eab-hmac-invalid'
@@ -79,7 +79,7 @@ class TestEab:
         conf.add_md(domains)
         conf.add_vhost(domains=domains)
         conf.install()
-        assert env.apache_restart() == 0
+        assert env.apache_restart() == 0, f'{env.apachectl_stderr}'
         md = env.await_error(domain)
         assert md['renewal']['errors'] > 0
         assert md['renewal']['last']['problem'] in [
@@ -105,7 +105,7 @@ class TestEab:
         conf.add_md(domains)
         conf.add_vhost(domains=domains)
         conf.install()
-        assert env.apache_restart() == 0
+        assert env.apache_restart() == 0, f'{env.apachectl_stderr}'
         md = env.await_error(domain)
         assert md['renewal']['errors'] > 0
         assert md['renewal']['last']['problem'] in [
@@ -131,7 +131,7 @@ class TestEab:
         conf.add_md(domains)
         conf.add_vhost(domains=domains)
         conf.install()
-        assert env.apache_restart() == 0
+        assert env.apache_restart() == 0, f'{env.apachectl_stderr}'
         md = env.await_error(domain)
         assert md['renewal']['errors'] > 0
         assert md['renewal']['last']['problem'] in [
@@ -158,7 +158,7 @@ class TestEab:
         conf.add_md(domains)
         conf.add_vhost(domains=domains)
         conf.install()
-        assert env.apache_restart() == 0
+        assert env.apache_restart() == 0, f'{env.apachectl_stderr}'
         assert env.await_completion(domains)
 
     def test_md_750_011(self, env):
@@ -174,7 +174,7 @@ class TestEab:
         conf.add_md([domain_b])
         conf.add_vhost(domains=[domain_b])
         conf.install()
-        assert env.apache_restart() == 0
+        assert env.apache_restart() == 0, f'{env.apachectl_stderr}'
         assert env.await_completion([domain_a], restart=False)
         md = env.await_error(domain_b)
         assert md['renewal']['errors'] > 0
@@ -202,7 +202,7 @@ class TestEab:
         conf.end_md()
         conf.add_vhost(domains=[domain_b])
         conf.install()
-        assert env.apache_restart() == 0
+        assert env.apache_restart() == 0, f'{env.apachectl_stderr}'
         assert env.await_completion([domain_b], restart=False)
         md = env.await_error(domain_a)
         assert md['renewal']['errors'] > 0
@@ -231,7 +231,7 @@ class TestEab:
         conf.end_md()
         conf.add_vhost(domains=[domain_b])
         conf.install()
-        assert env.apache_restart() == 0
+        assert env.apache_restart() == 0, f'{env.apachectl_stderr}'
         assert env.await_completion([domain_a, domain_b])
         md_a = env.get_md_status(domain_a)
         md_b = env.get_md_status(domain_b)
@@ -247,7 +247,7 @@ class TestEab:
         conf.add_md(domains)
         conf.add_vhost(domains=domains)
         conf.install()
-        assert env.apache_restart() == 0
+        assert env.apache_restart() == 0, f'{env.apachectl_stderr}'
         assert env.await_completion(domains)
         md_1 = env.get_md_status(domain)
         conf = MDConf(env)
@@ -258,7 +258,7 @@ class TestEab:
         conf.add_md(domains)
         conf.add_vhost(domains=domains)
         conf.install()
-        assert env.apache_restart() == 0
+        assert env.apache_restart() == 0, f'{env.apachectl_stderr}'
         assert env.await_completion(domains)
         md_2 = env.get_md_status(domain)
         assert md_1['ca'] != md_2['ca']
@@ -273,7 +273,7 @@ class TestEab:
         conf.add_md(domains)
         conf.add_vhost(domains=domains)
         conf.install()
-        assert env.apache_restart() == 0
+        assert env.apache_restart() == 0, f'{env.apachectl_stderr}'
         assert env.await_completion(domains)
         conf = MDConf(env)
         # this is another one of the values in conf/pebble-eab.json
@@ -282,7 +282,7 @@ class TestEab:
         conf.add_md(domains)
         conf.add_vhost(domains=domains)
         conf.install()
-        assert env.apache_restart() == 0
+        assert env.apache_restart() == 0, f'{env.apachectl_stderr}'
         assert env.await_error(domain)
         md = env.await_error(domain)
         assert md['renewal']['errors'] > 0
@@ -307,7 +307,7 @@ class TestEab:
         conf.add_md(domains)
         conf.add_vhost(domains=domains)
         conf.install()
-        assert env.apache_restart() == 0
+        assert env.apache_restart() == 0, f'{env.apachectl_stderr}'
         assert env.await_completion(domains)
         conf = MDConf(env)
         # this is another one of the values in conf/pebble-eab.json
@@ -317,7 +317,7 @@ class TestEab:
         conf.add_md(domains)
         conf.add_vhost(domains=domains)
         conf.install()
-        assert env.apache_restart() == 0
+        assert env.apache_restart() == 0, f'{env.apachectl_stderr}'
         assert env.await_error(domain)
         md = env.await_error(domain)
         assert md['renewal']['errors'] > 0
@@ -343,7 +343,7 @@ class TestEab:
         conf.end_md()
         conf.add_vhost(domains=domains)
         conf.install()
-        assert env.apache_restart() == 0
+        assert env.apache_restart() == 0, f'{env.apachectl_stderr}'
         md = env.await_error(domain)
         assert md['renewal']['errors'] > 0
         assert md['renewal']['last']['problem'] == 'urn:ietf:params:acme:error:externalAccountRequired'
@@ -432,5 +432,5 @@ class TestEab:
         conf.add_md(domains)
         conf.add_vhost(domains=domains)
         conf.install()
-        assert env.apache_restart() == 0
+        assert env.apache_restart() == 0, f'{env.apachectl_stderr}'
         assert env.await_completion(domains)

--- a/test/modules/md/test_751_sectigo.py
+++ b/test/modules/md/test_751_sectigo.py
@@ -46,7 +46,7 @@ class TestSectigo:
         env.check_acme()
         env.clear_store()
         MDConf(env).install()
-        assert env.apache_restart() == 0
+        assert env.apache_restart() == 0, f'{env.apachectl_stderr}'
 
     @pytest.fixture(autouse=True, scope='function')
     def _method_scope(self, env, request):
@@ -65,7 +65,7 @@ class TestSectigo:
         conf.end_md()
         conf.add_vhost(domains=domains)
         conf.install()
-        assert env.apache_restart() == 0
+        assert env.apache_restart() == 0, f'{env.apachectl_stderr}'
         assert env.await_completion(domains)
         r = env.curl_get(f"https://{domain}:{env.https_port}", options=[
             "--cacert", f"{env.test_dir}/data/sectigo-demo-root.pem"
@@ -83,7 +83,7 @@ class TestSectigo:
         conf.end_md()
         conf.add_vhost(domains=domains)
         conf.install()
-        assert env.apache_restart() == 0
+        assert env.apache_restart() == 0, f'{env.apachectl_stderr}'
         assert env.await_error(domain)
         md = env.get_md_status(domain)
         assert md['renewal']['errors'] > 0
@@ -101,7 +101,7 @@ class TestSectigo:
         conf.end_md()
         conf.add_vhost(domains=domains)
         conf.install()
-        assert env.apache_restart() == 0
+        assert env.apache_restart() == 0, f'{env.apachectl_stderr}'
         assert env.await_error(domain)
         md = env.get_md_status(domain)
         assert md['renewal']['errors'] > 0
@@ -120,7 +120,7 @@ class TestSectigo:
         conf.end_md()
         conf.add_vhost(domains=domains)
         conf.install()
-        assert env.apache_restart() == 0
+        assert env.apache_restart() == 0, f'{env.apachectl_stderr}'
         assert env.await_completion(domains)
         r = env.curl_get(f"https://{domain}:{env.https_port}", options=[
             "--cacert", f"{env.test_dir}/data/sectigo-demo-root.pem"
@@ -142,7 +142,7 @@ class TestSectigo:
         conf.end_md()
         conf.add_vhost(domains=domains)
         conf.install()
-        assert env.apache_restart() == 0
+        assert env.apache_restart() == 0, f'{env.apachectl_stderr}'
         assert env.await_completion(domains)
         r = env.curl_get(f"https://{domain2}:{env.https_port}", options=[
             "--cacert", f"{env.test_dir}/data/sectigo-demo-root.pem"
@@ -167,7 +167,7 @@ class TestSectigo:
         conf.end_md()
         conf.add_vhost(domains=domains)
         conf.install()
-        assert env.apache_restart() == 0
+        assert env.apache_restart() == 0, f'{env.apachectl_stderr}'
         assert env.await_completion(domains)
         r = env.curl_get(f"https://{domain}:{env.https_port}", options=[
             "--cacert", f"{env.test_dir}/data/sectigo-demo-root.pem"

--- a/test/modules/md/test_752_zerossl.py
+++ b/test/modules/md/test_752_zerossl.py
@@ -43,7 +43,7 @@ class TestZeroSSL:
         env.check_acme()
         env.clear_store()
         MDConf(env).install()
-        assert env.apache_restart() == 0
+        assert env.apache_restart() == 0, f'{env.apachectl_stderr}'
 
     @pytest.fixture(autouse=True, scope='function')
     def _method_scope(self, env, request):
@@ -66,7 +66,7 @@ class TestZeroSSL:
         conf.end_md()
         conf.add_vhost(domains=domains)
         conf.install()
-        assert env.apache_restart() == 0
+        assert env.apache_restart() == 0, f'{env.apachectl_stderr}'
         assert env.await_completion(domains)
         r = env.curl_get(f"https://{domain}:{env.https_port}", options=[
             "--cacert", f"{env.test_dir}/data/sectigo-demo-root.pem"
@@ -88,7 +88,7 @@ class TestZeroSSL:
         conf.end_md()
         conf.add_vhost(domains=domains)
         conf.install()
-        assert env.apache_restart() == 0
+        assert env.apache_restart() == 0, f'{env.apachectl_stderr}'
         assert env.await_error(domain)
         md = env.get_md_status(domain)
         assert md['renewal']['errors'] > 0
@@ -110,7 +110,7 @@ class TestZeroSSL:
         conf.end_md()
         conf.add_vhost(domains=domains)
         conf.install()
-        assert env.apache_restart() == 0
+        assert env.apache_restart() == 0, f'{env.apachectl_stderr}'
         assert env.await_error(domain)
         md = env.get_md_status(domain)
         assert md['renewal']['errors'] > 0
@@ -134,7 +134,7 @@ class TestZeroSSL:
         conf.end_md()
         conf.add_vhost(domains=domains)
         conf.install()
-        assert env.apache_restart() == 0
+        assert env.apache_restart() == 0, f'{env.apachectl_stderr}'
         assert env.await_completion(domains)
         r = env.curl_get(f"https://{domain}:{env.https_port}", options=[
             "--cacert", f"{env.test_dir}/data/sectigo-demo-root.pem"
@@ -160,7 +160,7 @@ class TestZeroSSL:
         conf.end_md()
         conf.add_vhost(domains=domains)
         conf.install()
-        assert env.apache_restart() == 0
+        assert env.apache_restart() == 0, f'{env.apachectl_stderr}'
         assert env.await_completion(domains)
         r = env.curl_get(f"https://{domain2}:{env.https_port}", options=[
             "--cacert", f"{env.test_dir}/data/sectigo-demo-root.pem"
@@ -188,7 +188,7 @@ class TestZeroSSL:
         conf.end_md()
         conf.add_vhost(domains=domains)
         conf.install()
-        assert env.apache_restart() == 0
+        assert env.apache_restart() == 0, f'{env.apachectl_stderr}'
         assert env.await_completion(domains)
         r = env.curl_get(f"https://{domain}:{env.https_port}", options=[
             "--cacert", f"{env.test_dir}/data/sectigo-demo-root.pem"

--- a/test/modules/md/test_780_tailscale.py
+++ b/test/modules/md/test_780_tailscale.py
@@ -103,7 +103,7 @@ class TestTailscale:
         acme.start(config='default')
         env.clear_store()
         MDConf(env).install()
-        assert env.apache_restart() == 0
+        assert env.apache_restart() == 0, f'{env.apachectl_stderr}'
         yield
         faker.stop()
 
@@ -133,7 +133,7 @@ class TestTailscale:
         conf.add_vhost(domains)
         conf.install()
         # restart and watch it fail due to wrong tailscale unix socket path
-        assert env.apache_restart() == 0
+        assert env.apache_restart() == 0, f'{env.apachectl_stderr}'
         md = env.await_error(domain)
         assert md
         assert md['renewal']['errors'] > 0
@@ -163,9 +163,9 @@ class TestTailscale:
         conf.add_vhost(domains)
         conf.install()
         # restart and watch it fail due to wrong tailscale unix socket path
-        assert env.apache_restart() == 0
+        assert env.apache_restart() == 0, f'{env.apachectl_stderr}'
         assert env.await_completion(domains)
-        assert env.apache_restart() == 0
+        assert env.apache_restart() == 0, f'{env.apachectl_stderr}'
         env.check_md_complete(domain)
 
     # create a MD using `tailscale` as protocol, but domain name not assigned by tailscale
@@ -184,7 +184,7 @@ class TestTailscale:
         conf.add_vhost(domains)
         conf.install()
         # restart and watch it fail due to wrong tailscale unix socket path
-        assert env.apache_restart() == 0
+        assert env.apache_restart() == 0, f'{env.apachectl_stderr}'
         md = env.await_error(domain)
         assert md
         assert md['renewal']['errors'] > 0

--- a/test/modules/md/test_790_failover.py
+++ b/test/modules/md/test_790_failover.py
@@ -16,7 +16,7 @@ class TestFailover:
         conf = MDConf(env)
         conf.install()
 
-        assert env.apache_restart() == 0
+        assert env.apache_restart() == 0, f'{env.apachectl_stderr}'
 
     @pytest.fixture(autouse=True, scope='function')
     def _method_scope(self, env, request):
@@ -39,7 +39,7 @@ class TestFailover:
         conf.end_md()
         conf.add_vhost(domains)
         conf.install()
-        assert env.apache_restart() == 0
+        assert env.apache_restart() == 0, f'{env.apachectl_stderr}'
         assert env.await_completion([domain])
         env.check_md_complete(domain)
 
@@ -60,7 +60,7 @@ class TestFailover:
         conf.end_md()
         conf.add_vhost(domains)
         conf.install()
-        assert env.apache_restart() == 0
+        assert env.apache_restart() == 0, f'{env.apachectl_stderr}'
         assert env.await_completion([domain])
         env.check_md_complete(domain)
         #
@@ -91,7 +91,7 @@ class TestFailover:
         conf.end_md()
         conf.add_vhost(domains)
         conf.install()
-        assert env.apache_restart() == 0
+        assert env.apache_restart() == 0, f'{env.apachectl_stderr}'
         assert env.await_completion([domain])
         env.check_md_complete(domain)
         #

--- a/test/modules/md/test_800_must_staple.py
+++ b/test/modules/md/test_800_must_staple.py
@@ -17,7 +17,7 @@ class TestMustStaple:
         env.check_acme()
         env.clear_store()
         MDConf(env).install()
-        assert env.apache_restart() == 0
+        assert env.apache_restart() == 0, f'{env.apachectl_stderr}'
 
     @pytest.fixture(autouse=True, scope='function')
     def _method_scope(self, env, request):
@@ -33,7 +33,7 @@ class TestMustStaple:
     # MD with default, e.g. not staple
     def test_md_800_001(self, env):
         self.configure_httpd(env, self.domain)
-        assert env.apache_restart() == 0
+        assert env.apache_restart() == 0, f'{env.apachectl_stderr}'
         assert env.await_completion([self.domain])
         env.check_md_complete(self.domain)
         cert1 = MDCertUtil(env.store_domain_file(self.domain, 'pubcert.pem'))
@@ -42,7 +42,7 @@ class TestMustStaple:
     # MD that should explicitly not staple
     def test_md_800_002(self, env):
         self.configure_httpd(env, self.domain, "MDMustStaple off")
-        assert env.apache_restart() == 0
+        assert env.apache_restart() == 0, f'{env.apachectl_stderr}'
         env.check_md_complete(self.domain)
         cert1 = MDCertUtil(env.store_domain_file(self.domain, 'pubcert.pem'))
         assert not cert1.get_must_staple()
@@ -53,13 +53,13 @@ class TestMustStaple:
     @pytest.mark.skipif(MDTestEnv.lacks_ocsp(), reason="no OCSP responder")
     def test_md_800_003(self, env):
         self.configure_httpd(env, self.domain, "MDMustStaple on")
-        assert env.apache_restart() == 0
+        assert env.apache_restart() == 0, f'{env.apachectl_stderr}'
         assert env.await_completion([self.domain])
         env.check_md_complete(self.domain)
         cert1 = MDCertUtil(env.store_domain_file(self.domain, 'pubcert.pem'))
         assert cert1.get_must_staple()
         self.configure_httpd(env, self.domain, "MDMustStaple off")
-        assert env.apache_restart() == 0
+        assert env.apache_restart() == 0, f'{env.apachectl_stderr}'
         assert env.await_completion([self.domain])
         env.check_md_complete(self.domain)
         cert1 = MDCertUtil(env.store_domain_file(self.domain, 'pubcert.pem'))
@@ -78,7 +78,7 @@ class TestMustStaple:
             SSLUseStapling On
             SSLStaplingCache shmcb:stapling_cache(128000)
             """)
-        assert env.apache_restart() == 0
+        assert env.apache_restart() == 0, f'{env.apachectl_stderr}'
         stat = env.get_ocsp_status(self.domain)
         assert stat['ocsp'] == "successful (0x0)" 
         assert stat['verify'] == "0 (ok)"

--- a/test/modules/md/test_801_stapling.py
+++ b/test/modules/md/test_801_stapling.py
@@ -24,7 +24,7 @@ class TestStapling:
         mdB = "b-" + domain
         self.configure_httpd(env, [mdA, mdB]).install()
         env.apache_stop()
-        assert env.apache_restart() == 0
+        assert env.apache_restart() == 0, f'{env.apachectl_stderr}'
         assert env.await_completion([mdA, mdB])
         env.check_md_complete(mdA)
         env.check_md_complete(mdB)
@@ -67,10 +67,10 @@ class TestStapling:
     def test_md_801_001(self, env):
         md = self.mdA
         self.configure_httpd(env, md).install()
-        assert env.apache_restart() == 0
+        assert env.apache_restart() == 0, f'{env.apachectl_stderr}'
         stat = env.get_ocsp_status(md)
         if MDTestEnv.lacks_ocsp():
-            assert 'ocsp' not in stat, f'{stat}'
+            assert 'ocsp' not in stat or stat['ocsp'] == "no response sent", f'{stat}'
         else:
             assert stat['ocsp'] == "no response sent"
         stat = env.get_md_status(md)
@@ -81,10 +81,10 @@ class TestStapling:
             MDStapling on
             LogLevel md:trace5
             """).install()
-        assert env.apache_restart() == 0
+        assert env.apache_restart() == 0, f'{env.apachectl_stderr}'
         if MDTestEnv.lacks_ocsp():
             stat = env.get_md_status(md)
-            assert 'ocsp' not in stat, f'{stat}'
+            assert 'ocsp' not in stat or stat['ocsp'] == "no response sent", f'{stat}'
         else:
             stat = env.await_ocsp_status(md)
             assert stat['ocsp'] == "successful (0x0)"
@@ -102,10 +102,10 @@ class TestStapling:
         #
         # turn stapling off (explicitly) again, should disappear
         self.configure_httpd(env, md, "MDStapling off").install()
-        assert env.apache_restart() == 0
+        assert env.apache_restart() == 0, f'{env.apachectl_stderr}'
         stat = env.get_ocsp_status(md)
         if MDTestEnv.lacks_ocsp():
-            assert 'ocsp' not in stat, f'{stat}'
+            assert 'ocsp' not in stat or stat['ocsp'] == "no response sent", f'{stat}'
         else:
             assert stat['ocsp'] == "no response sent"
         stat = env.get_md_status(md)
@@ -117,7 +117,7 @@ class TestStapling:
     def test_md_801_002(self, env):
         md = self.mdA
         self.configure_httpd(env, md, ssl_stapling=True).install()
-        assert env.apache_restart() == 0
+        assert env.apache_restart() == 0, f'{env.apachectl_stderr}'
         stat = env.get_ocsp_status(md)
         assert stat['ocsp'] == "successful (0x0)" if \
             env.ssl_module == "mod_ssl" else "no response sent"
@@ -126,7 +126,7 @@ class TestStapling:
         #
         # turn stapling on, wait for it to appear in connections
         self.configure_httpd(env, md, "MDStapling on", ssl_stapling=True).install()
-        assert env.apache_restart() == 0
+        assert env.apache_restart() == 0, f'{env.apachectl_stderr}'
         stat = env.await_ocsp_status(md)
         assert stat['ocsp'] == "successful (0x0)" 
         assert stat['verify'] == "0 (ok)"
@@ -138,7 +138,7 @@ class TestStapling:
         #
         # turn stapling off (explicitly) again, should disappear
         self.configure_httpd(env, md, "MDStapling off", ssl_stapling=True).install()
-        assert env.apache_restart() == 0
+        assert env.apache_restart() == 0, f'{env.apachectl_stderr}'
         stat = env.get_ocsp_status(md)
         assert stat['ocsp'] == "successful (0x0)" if \
             env.ssl_module == "mod_ssl" else "no response sent"
@@ -160,11 +160,11 @@ class TestStapling:
         conf.add_vhost(md_a)
         conf.add_vhost(md_b)
         conf.install()
-        assert env.apache_restart() == 0
+        assert env.apache_restart() == 0, f'{env.apachectl_stderr}'
         # mdA has stapling
         if MDTestEnv.lacks_ocsp():
             stat = env.get_ocsp_status(md_a)
-            assert 'ocsp' not in stat, f'{stat}'
+            assert 'ocsp' not in stat or stat['ocsp'] == "no response sent", f'{stat}'
         else:
             stat = env.await_ocsp_status(md_a)
             assert stat['ocsp'] == "successful (0x0)"
@@ -198,7 +198,7 @@ class TestStapling:
         conf.add_vhost(md_a)
         conf.add_vhost(md_b)
         conf.install()
-        assert env.apache_restart() == 0
+        assert env.apache_restart() == 0, f'{env.apachectl_stderr}'
         # mdA has stapling
         stat = env.await_ocsp_status(md_a)
         assert stat['ocsp'] == "successful (0x0)"
@@ -223,7 +223,7 @@ class TestStapling:
         # turn stapling on, wait for it to appear in connections
         md = self.mdA
         self.configure_httpd(env, md, "MDStapling on").install()
-        assert env.apache_restart() == 0
+        assert env.apache_restart() == 0, f'{env.apachectl_stderr}'
         stat = env.await_ocsp_status(md)
         assert stat['ocsp'] == "successful (0x0)" 
         assert stat['verify'] == "0 (ok)"
@@ -238,7 +238,7 @@ class TestStapling:
         mtime1 = os.path.getmtime(ocsp_file)
         # wait a sec, restart and check that file does not change
         time.sleep(1)
-        assert env.apache_restart() == 0
+        assert env.apache_restart() == 0, f'{env.apachectl_stderr}'
         stat = env.await_ocsp_status(md)
         assert stat['ocsp'] == "successful (0x0)" 
         mtime2 = os.path.getmtime(ocsp_file)
@@ -250,12 +250,12 @@ class TestStapling:
             MDStapling on
             MDStaplingKeepResponse 1s
             """).install()
-        assert env.apache_restart() == 0
+        assert env.apache_restart() == 0, f'{env.apachectl_stderr}'
         stat = env.await_ocsp_status(md)
         assert stat['ocsp'] == "successful (0x0)"
         assert not os.path.exists(ocsp_file)
         # if we restart again, a new file needs to appear
-        assert env.apache_restart() == 0
+        assert env.apache_restart() == 0, f'{env.apachectl_stderr}'
         stat = env.await_ocsp_status(md)
         assert stat['ocsp'] == "successful (0x0)"
         mtime3 = os.path.getmtime(ocsp_file)
@@ -268,7 +268,7 @@ class TestStapling:
         # turn stapling on, wait for it to appear in connections
         md = self.mdA
         self.configure_httpd(env, md, "MDStapling on").install()
-        assert env.apache_restart() == 0
+        assert env.apache_restart() == 0, f'{env.apachectl_stderr}'
         stat = env.await_ocsp_status(md)
         assert stat['ocsp'] == "successful (0x0)" 
         assert stat['verify'] == "0 (ok)"
@@ -281,7 +281,7 @@ class TestStapling:
                 ocsp_file = os.path.join(dirpath, name)
         assert ocsp_file
         mtime1 = os.path.getmtime(ocsp_file)
-        assert env.apache_restart() == 0
+        assert env.apache_restart() == 0, f'{env.apachectl_stderr}'
         stat = env.await_ocsp_status(md)
         assert stat['ocsp'] == "successful (0x0)" 
         # wait a sec, restart and check that file does not change
@@ -293,7 +293,7 @@ class TestStapling:
             MDStapling on
             MDStaplingRenewWindow 10d
             """).install()
-        assert env.apache_restart() == 0
+        assert env.apache_restart() == 0, f'{env.apachectl_stderr}'
         stat = env.await_ocsp_status(md)
         assert stat['ocsp'] == "successful (0x0)"
         # wait a sec, restart and check that file does change
@@ -317,7 +317,7 @@ class TestStapling:
                    env.store_domain_file(md, 'pubcert.pem')))
         conf.add_vhost(md)
         conf.install()
-        assert env.apache_restart() == 0
+        assert env.apache_restart() == 0, f'{env.apachectl_stderr}'
         stat = env.await_ocsp_status(md)
         assert stat['ocsp'] == "successful (0x0)" 
         assert stat['verify'] == "0 (ok)"
@@ -342,7 +342,7 @@ class TestStapling:
                              env.store_domain_file(md, 'privkey.pem'))
         conf.end_vhost()
         conf.install()
-        assert env.apache_restart() == 0
+        assert env.apache_restart() == 0, f'{env.apachectl_stderr}'
         stat = env.await_ocsp_status(md)
         assert stat['ocsp'] == "successful (0x0)" 
         assert stat['verify'] == "0 (ok)"
@@ -380,7 +380,7 @@ class TestStapling:
         conf.end_md()
         conf.add_vhost(md)
         conf.install()
-        assert env.apache_restart() == 0
+        assert env.apache_restart() == 0, f'{env.apachectl_stderr}'
         time.sleep(1)
         stat = env.get_ocsp_status(md)
         assert stat['ocsp'] == "no response sent" 
@@ -397,7 +397,7 @@ class TestStapling:
         conf.add("MDStapling on")
         conf.end_md()
         conf.install()
-        assert env.apache_restart() == 0
+        assert env.apache_restart() == 0, f'{env.apachectl_stderr}'
         stat = env.get_server_status()
         assert stat
 
@@ -414,9 +414,9 @@ class TestStapling:
             MDStapling on
             LogLevel md:trace2 ssl:warn
             """).install()
-        assert env.apache_restart() == 0
+        assert env.apache_restart() == 0, f'{env.apachectl_stderr}'
         assert env.await_completion(domains, restart=False, timeout=120)
-        assert env.apache_restart() == 0
+        assert env.apache_restart() == 0, f'{env.apachectl_stderr}'
         # now the certs are installed and ocsp will be retrieved
         time.sleep(1)
         for domain in domains:

--- a/test/modules/md/test_810_ec.py
+++ b/test/modules/md/test_810_ec.py
@@ -18,7 +18,7 @@ class TestAutov2:
         env.check_acme()
         env.clear_store()
         MDConf(env).install()
-        assert env.apache_restart() == 0
+        assert env.apache_restart() == 0, f'{env.apachectl_stderr}'
 
     @pytest.fixture(autouse=True, scope='function')
     def _method_scope(self, env, request):
@@ -33,7 +33,7 @@ class TestAutov2:
             conf.add_md(domains)
             conf.add_vhost(domains)
         conf.install()
-        assert env.apache_restart() == 0
+        assert env.apache_restart() == 0, f'{env.apachectl_stderr}'
         assert env.await_completion([domain])
 
     def check_pkeys(self, env, domain, pkeys):
@@ -100,7 +100,7 @@ class TestAutov2:
         conf.add_md(domains)
         conf.add_vhost(domains)
         conf.install()
-        assert env.apache_restart() == 0
+        assert env.apache_restart() == 0, f'{env.apachectl_stderr}'
         md = env.await_error(domain)
         assert md
         assert md['renewal']['errors'] > 0
@@ -135,14 +135,14 @@ class TestAutov2:
         conf.add_md(domains)
         conf.add_vhost(domains)
         conf.install()
-        assert env.apache_restart() == 0
+        assert env.apache_restart() == 0, f'{env.apachectl_stderr}'
         assert env.await_completion(domains)
         conf = MDConf(env)
         conf.add("MDPrivateKeys rsa3072 secp384r1")
         conf.add_md(domains)
         conf.add_vhost(domains)
         conf.install()
-        assert env.apache_restart() == 0
+        assert env.apache_restart() == 0, f'{env.apachectl_stderr}'
         mds = env.get_md_status(domain, via_domain=domain, use_https=True)
         assert 'renew' in mds and mds['renew'] is True, f"{mds}"
         assert env.await_completion(domains)

--- a/test/modules/md/test_820_locks.py
+++ b/test/modules/md/test_820_locks.py
@@ -37,7 +37,7 @@ class TestLocks:
         self.configure_httpd(env, [domain], add_lines=[
             "MDStoreLocks 1s"
         ])
-        assert env.apache_restart() == 0
+        assert env.apache_restart() == 0, f'{env.apachectl_stderr}'
         assert env.await_completion([domain])
 
     # renewal, with global lock held during restert
@@ -47,26 +47,26 @@ class TestLocks:
         self.configure_httpd(env, [domain], add_lines=[
             "MDStoreLocks 1s"
         ])
-        assert env.apache_restart() == 0
+        assert env.apache_restart() == 0, f'{env.apachectl_stderr}'
         assert env.await_completion([domain])
         # we have a cert now, add a dns name to force renewal
         certa = MDCertUtil(env.store_domain_file(domain, 'pubcert.pem'))
         self.configure_httpd(env, [domain, f"x.{domain}"], add_lines=[
             "MDStoreLocks 1s"
         ])
-        assert env.apache_restart() == 0
+        assert env.apache_restart() == 0, f'{env.apachectl_stderr}'
         # await new cert, but do not restart, keeps the cert in staging
         assert env.await_completion([domain], restart=False)
         # obtain global lock and restart
         lockfile = os.path.join(env.store_dir, "store.lock")
         with FileLock(lockfile):
-            assert env.apache_restart() == 0
+            assert env.apache_restart() == 0, f'{env.apachectl_stderr}'
         # lock should have prevented staging from being activated,
         # meaning we will have the same cert
         certb = MDCertUtil(env.store_domain_file(domain, 'pubcert.pem'))
         assert certa.same_serial_as(certb)
         # now restart without lock
-        assert env.apache_restart() == 0
+        assert env.apache_restart() == 0, f'{env.apachectl_stderr}'
         certc = MDCertUtil(env.store_domain_file(domain, 'pubcert.pem'))
         assert not certa.same_serial_as(certc)
 

--- a/test/modules/md/test_900_notify.py
+++ b/test/modules/md/test_900_notify.py
@@ -45,7 +45,7 @@ class TestNotify:
         self.configure_httpd(env, self.domain, f"""
             MDNotifyCmd {command} {args}
             """)
-        assert env.apache_restart() == 0
+        assert env.apache_restart() == 0, f'{env.apachectl_stderr}'
         assert env.await_error(self.domain)
         stat = env.get_md_status(self.domain)
         assert stat["renewal"]["last"]["problem"] == "urn:org:apache:httpd:log:AH10108:"
@@ -63,7 +63,7 @@ class TestNotify:
         self.configure_httpd(env, self.domain, f"""
             MDNotifyCmd {command} {args}
             """)
-        assert env.apache_restart() == 0
+        assert env.apache_restart() == 0, f'{env.apachectl_stderr}'
         assert env.await_error(self.domain)
         stat = env.get_md_status(self.domain)
         assert stat["renewal"]["last"]["problem"] == "urn:org:apache:httpd:log:AH10108:"
@@ -83,7 +83,7 @@ class TestNotify:
         self.configure_httpd(env, self.domain, f"""
             MDNotifyCmd {command} {args}
             """)
-        assert env.apache_restart() == 0
+        assert env.apache_restart() == 0, f'{env.apachectl_stderr}'
         assert env.await_completion([self.domain], restart=False)
         time.sleep(1)
         stat = env.get_md_status(self.domain)
@@ -102,7 +102,7 @@ class TestNotify:
         self.configure_httpd(env, self.domain, f"""
             MDNotifyCmd {command} {args} {extra_arg}
             """)
-        assert env.apache_restart() == 0
+        assert env.apache_restart() == 0, f'{env.apachectl_stderr}'
         assert env.await_completion([self.domain], restart=False)
         time.sleep(1)
         stat = env.get_md_status(self.domain)
@@ -125,7 +125,7 @@ class TestNotify:
         conf.add_vhost(domains1)
         conf.add_vhost(domains2)
         conf.install()
-        assert env.apache_restart() == 0
+        assert env.apache_restart() == 0, f'{env.apachectl_stderr}'
         assert env.await_completion([md1, md2], restart=False)
         time.sleep(1)
         stat = env.get_md_status(md1)

--- a/test/modules/md/test_901_message.py
+++ b/test/modules/md/test_901_message.py
@@ -22,7 +22,7 @@ class TestMessage:
         env.check_acme()
         env.clear_store()
         MDConf(env).install()
-        assert env.apache_restart() == 0
+        assert env.apache_restart() == 0, f'{env.apachectl_stderr}'
 
     @pytest.fixture(autouse=True, scope='function')
     def _method_scope(self, env, request):
@@ -43,7 +43,7 @@ class TestMessage:
         conf.add_md(domains)
         conf.add_vhost(domains)
         conf.install()
-        assert env.apache_restart() == 0
+        assert env.apache_restart() == 0, f'{env.apachectl_stderr}'
         assert env.await_file(env.store_staged_file(domain, 'job.json'))
         stat = env.get_md_status(domain)
         # this command should have failed and logged an error
@@ -70,7 +70,7 @@ class TestMessage:
         conf.add_md(domains)
         conf.add_vhost(domains)
         conf.install()
-        assert env.apache_restart() == 0
+        assert env.apache_restart() == 0, f'{env.apachectl_stderr}'
         assert env.await_error(domain)
         stat = env.get_md_status(domain)
         # this command should have failed and logged an error
@@ -96,7 +96,7 @@ class TestMessage:
         conf.add_md(domains)
         conf.add_vhost(domains)
         conf.install()
-        assert env.apache_restart() == 0
+        assert env.apache_restart() == 0, f'{env.apachectl_stderr}'
         assert env.await_completion([domain], restart=False)
         time.sleep(1)
         stat = env.get_md_status(domain)
@@ -134,7 +134,7 @@ class TestMessage:
         conf.add_md(domains)
         conf.add_vhost(domains)
         conf.install()
-        assert env.apache_restart() == 0
+        assert env.apache_restart() == 0, f'{env.apachectl_stderr}'
         assert env.await_completion([domain])
         # force renew
         conf = MDConf(env)
@@ -144,7 +144,7 @@ class TestMessage:
         conf.add_md(domains)
         conf.add_vhost(domains)
         conf.install()
-        assert env.apache_restart() == 0
+        assert env.apache_restart() == 0, f'{env.apachectl_stderr}'
         assert env.await_completion([domain], restart=False)
         env.get_md_status(domain)
         assert env.await_file(self.mlog)
@@ -175,7 +175,7 @@ class TestMessage:
         conf.end_md()
         conf.add_vhost(domain)
         conf.install()
-        assert env.apache_restart() == 0
+        assert env.apache_restart() == 0, f'{env.apachectl_stderr}'
         assert not os.path.isfile(self.mlog)
         
     def test_md_901_011(self, env):
@@ -201,13 +201,13 @@ class TestMessage:
         conf.end_md()
         conf.add_vhost(domain)
         conf.install()
-        assert env.apache_restart() == 0
+        assert env.apache_restart() == 0, f'{env.apachectl_stderr}'
         assert env.await_file(self.mlog)
         nlines = open(self.mlog).readlines()
         assert len(nlines) == 1
         assert nlines[0].strip() == f"['{self.mcmd}', '{self.mlog}', 'expiring', '{domain}']"
         # check that we do not get it resend right away again
-        assert env.apache_restart() == 0
+        assert env.apache_restart() == 0, f'{env.apachectl_stderr}'
         time.sleep(1)
         nlines = open(self.mlog).readlines()
         assert len(nlines) == 1
@@ -225,7 +225,7 @@ class TestMessage:
         conf.add("MDStapling on")
         conf.add_vhost(domains)
         conf.install()
-        assert env.apache_restart() == 0
+        assert env.apache_restart() == 0, f'{env.apachectl_stderr}'
         assert env.await_completion([domain])
         env.await_ocsp_status(domain)
         assert env.await_file(self.mlog)
@@ -251,7 +251,7 @@ class TestMessage:
         conf.add_md(domains)
         conf.add_vhost(domains)
         conf.install()
-        assert env.apache_restart() == 0
+        assert env.apache_restart() == 0, f'{env.apachectl_stderr}'
         assert env.await_completion([domain])
         # set the warn window that triggers right away and a failing message command
         conf = MDConf(env)
@@ -262,7 +262,7 @@ class TestMessage:
             """)
         conf.add_vhost(domains)
         conf.install()
-        assert env.apache_restart() == 0
+        assert env.apache_restart() == 0, f'{env.apachectl_stderr}'
         env.get_md_status(domain)
         # this command should have failed and logged an error
         # shut down server to make sure that md has completed
@@ -285,7 +285,7 @@ class TestMessage:
             """)
         conf.add_vhost(domains)
         conf.install()
-        assert env.apache_restart() == 0
+        assert env.apache_restart() == 0, f'{env.apachectl_stderr}'
         assert env.await_file(self.mlog)
         # we see the notification logged by the command
         nlines = open(self.mlog).readlines()
@@ -308,7 +308,7 @@ class TestMessage:
         conf.add_md(domains)
         conf.add_vhost(domains)
         conf.install()
-        assert env.apache_restart() == 0
+        assert env.apache_restart() == 0, f'{env.apachectl_stderr}'
         assert env.await_error(domain)
         assert env.await_file(self.mlog)
         time.sleep(1)

--- a/test/modules/md/test_910_cleanups.py
+++ b/test/modules/md/test_910_cleanups.py
@@ -19,7 +19,7 @@ class TestCleanups:
         env.check_acme()
         env.clear_store()
         MDConf(env).install()
-        assert env.apache_restart() == 0
+        assert env.apache_restart() == 0, f'{env.apachectl_stderr}'
 
     @pytest.fixture(autouse=True, scope='function')
     def _method_scope(self, env, request):
@@ -45,7 +45,7 @@ class TestCleanups:
         for name in dirs_before:
             os.makedirs(os.path.join(challenges_dir, name))
 
-        assert env.apache_restart() == 0
+        assert env.apache_restart() == 0, f'{env.apachectl_stderr}'
         # the one we use is still there
         assert os.path.isdir(os.path.join(challenges_dir, domain))
         # and the others are gone

--- a/test/modules/md/test_920_status.py
+++ b/test/modules/md/test_920_status.py
@@ -36,7 +36,7 @@ class TestStatus:
         conf.add_md(domains)
         conf.add_vhost(domain)
         conf.install()
-        assert env.apache_restart() == 0
+        assert env.apache_restart() == 0, f'{env.apachectl_stderr}'
         assert env.await_completion([domain], restart=False)
         # we started without a valid certificate, so we expect /.httpd/certificate-status
         # to not give information about one and - since we waited for the ACME signup
@@ -49,7 +49,7 @@ class TestStatus:
         assert 'sha256-fingerprint' in status['renewal']['cert']['rsa']
         # restart and activate
         # once activated, the staging must be gone and attributes exist for the active cert
-        assert env.apache_restart() == 0
+        assert env.apache_restart() == 0, f'{env.apachectl_stderr}'
         status = env.get_certificate_status(domain)
         assert 'renewal' not in status
         assert 'sha256-fingerprint' in status['rsa']
@@ -64,7 +64,7 @@ class TestStatus:
         conf.add_md(domains)
         conf.add_vhost(domain)
         conf.install()
-        assert env.apache_restart() == 0
+        assert env.apache_restart() == 0, f'{env.apachectl_stderr}'
         assert env.await_completion([domain], restart=False)
         # copy a real certificate from LE over to staging
         staged_cert = os.path.join(env.store_dir, 'staging', domain, 'pubcert.pem')
@@ -87,7 +87,7 @@ class TestStatus:
         conf.add("MDCertificateStatus off")
         conf.add_vhost(domain)
         conf.install()
-        assert env.apache_restart() == 0
+        assert env.apache_restart() == 0, f'{env.apachectl_stderr}'
         assert env.await_completion([domain], restart=False)
         status = env.get_certificate_status(domain)
         assert not status
@@ -100,7 +100,7 @@ class TestStatus:
         conf.add("MDCertificateStatus off")
         conf.add_vhost(domain)
         conf.install()
-        assert env.apache_restart() == 0
+        assert env.apache_restart() == 0, f'{env.apachectl_stderr}'
         assert env.await_completion([domain])
         status = env.get_md_status("")
         assert "version" in status
@@ -138,7 +138,7 @@ Protocols h2 http/1.1 acme-tls/1
             """)
         conf.add_md(domains)
         conf.install()
-        assert env.apache_restart() == 0
+        assert env.apache_restart() == 0, f'{env.apachectl_stderr}'
         assert env.await_completion([domain], restart=False,
                                     via_domain=env.http_addr, use_https=False)
         status = env.get_md_status("", via_domain=env.http_addr, use_https=False)
@@ -208,7 +208,7 @@ Protocols h2 http/1.1 acme-tls/1
         conf.add("SSLEngine off")
         conf.end_vhost()
         conf.install()
-        assert env.apache_restart() == 0
+        assert env.apache_restart() == 0, f'{env.apachectl_stderr}'
         status = env.get_md_status(domain, via_domain=env.http_addr, use_https=False)
         assert status
         assert 'renewal' not in status
@@ -226,7 +226,7 @@ Protocols h2 http/1.1 acme-tls/1
         conf.add_md(domains)
         conf.add_vhost(domain)
         conf.install()
-        assert env.apache_restart() == 0
+        assert env.apache_restart() == 0, f'{env.apachectl_stderr}'
         assert env.await_completion([domain], restart=False)
         # In the stats JSON, we expect 2 certificates under 'renewal'
         stat = env.get_md_status(domain)
@@ -242,7 +242,7 @@ Protocols h2 http/1.1 acme-tls/1
         assert 'rsa' in status['renewal']['cert']
         # restart and activate
         # once activated, certs are listed in status
-        assert env.apache_restart() == 0
+        assert env.apache_restart() == 0, f'{env.apachectl_stderr}'
         stat = env.get_md_status(domain)
         assert 'cert' in stat
         assert 'valid' in stat['cert']

--- a/test/pyhttpd/conf/httpd.conf.template
+++ b/test/pyhttpd/conf/httpd.conf.template
@@ -3,7 +3,7 @@ ServerRoot "${server_dir}"
 
 # not in 2.4.x
 #DefaultRuntimeDir logs
-#PidFile httpd.pid
+PidFile "${server_dir}/logs/httpd.pid"
 
 Include "conf/modules.conf"
 

--- a/test/pyhttpd/conf/stop.conf.template
+++ b/test/pyhttpd/conf/stop.conf.template
@@ -5,6 +5,10 @@
 ServerName localhost
 ServerRoot "${server_dir}"
 
+# not in 2.4.x
+#DefaultRuntimeDir logs
+PidFile "${server_dir}/logs/httpd.pid"
+
 Include "conf/modules.conf"
 
 DocumentRoot "${server_dir}/htdocs"

--- a/test/pyhttpd/config.ini.in
+++ b/test/pyhttpd/config.ini.in
@@ -12,7 +12,7 @@ libexecdir = @libexecdir@
 
 apr_bindir = @APR_BINDIR@
 apxs = @bindir@/apxs
-apachectl = @sbindir@/apachectl
+httpd = @HTTPD@
 
 [httpd]
 version = @HTTPD_VERSION@
@@ -21,6 +21,7 @@ dso_modules = @DSO_MODULES@
 mpm_modules = @MPM_MODULES@
 
 [test]
+src_dir = @abs_top_srcdir@
 gen_dir = @abs_srcdir@/../gen
 http_port = 5002
 https_port = 5001

--- a/test/pyhttpd/env.py
+++ b/test/pyhttpd/env.py
@@ -10,7 +10,7 @@ import sys
 import time
 from datetime import datetime, timedelta
 from string import Template
-from typing import List, Optional
+from typing import List, Optional, Tuple
 
 from configparser import ConfigParser, ExtendedInterpolation
 from urllib.parse import urlparse
@@ -72,6 +72,7 @@ class HttpdTestSetup:
         self._source_dirs = [os.path.dirname(inspect.getfile(HttpdTestSetup))]
         self._modules = HttpdTestSetup.MODULES.copy()
         self._optional_modules = []
+        self._local_modules = []
 
     def add_source_dir(self, source_dir):
         self._source_dirs.append(source_dir)
@@ -81,6 +82,9 @@ class HttpdTestSetup:
 
     def add_optional_modules(self, modules: List[str]):
         self._optional_modules.extend(modules)
+
+    def add_local_module(self, mod_name: str, mod_path: str):
+        self._local_modules.append((mod_name, mod_path))
 
     def make(self):
         self._make_dirs()
@@ -92,6 +96,7 @@ class HttpdTestSetup:
             self.add_modules([self.env.ssl_module])
         self._make_modules_conf()
         self._make_htdocs()
+        self._add_local_modules()
         self._add_aptest()
         self.env.clear_curl_headerfiles()
 
@@ -196,6 +201,14 @@ class HttpdTestSetup:
             # load our test module which is not installed
             fd.write(f"LoadModule aptest_module   \"{local_dir}/mod_aptest/.libs/mod_aptest.so\"\n")
 
+    def _add_local_modules(self):
+        if len(self._local_modules):
+            modules_conf = os.path.join(self.env.server_dir, 'conf/modules.conf')
+            with open(modules_conf, 'a') as fd:
+                for mod_name, mod_path in self._local_modules:
+                    mod_path = os.path.join(self.env.src_dir, mod_path)
+                    fd.write(f"LoadModule {mod_name}_module   \"{mod_path}\"\n")
+
 
 class HttpdTestEnv:
 
@@ -233,7 +246,7 @@ class HttpdTestEnv:
         self._bin_dir = self.config.get('global', 'bindir')
         self._apxs = self.config.get('global', 'apxs')
         self._prefix = self.config.get('global', 'prefix')
-        self._apachectl = self.config.get('global', 'apachectl')
+        self._httpd = self.config.get('global', 'httpd')
         if HttpdTestEnv.LIBEXEC_DIR is None:
             HttpdTestEnv.LIBEXEC_DIR = self._libexec_dir = self.get_apxs_var('LIBEXECDIR')
         self._curl = self.config.get('global', 'curl_bin')
@@ -254,14 +267,17 @@ class HttpdTestEnv:
         self._http_tld = self.config.get('test', 'http_tld')
         self._test_dir = self.config.get('test', 'test_dir')
         self._clients_dir = os.path.join(os.path.dirname(self._test_dir), 'clients')
+        self._src_dir = self.config.get('test', 'src_dir')
         self._gen_dir = self.config.get('test', 'gen_dir')
         self._server_dir = os.path.join(self._gen_dir, 'apache')
         self._server_conf_dir = os.path.join(self._server_dir, "conf")
         self._server_docs_dir = os.path.join(self._server_dir, "htdocs")
+        self._server_lock_dir = os.path.join(self.server_dir, "locks")
         self._server_logs_dir = os.path.join(self.server_dir, "logs")
+        self._server_run_dir = os.path.join(self.server_dir, "run")
         self._server_access_log = os.path.join(self._server_logs_dir, "access_log")
         self._error_log = HttpdErrorLog(os.path.join(self._server_logs_dir, "error_log"))
-        self._apachectl_stderr = None
+        self._httpd_cmd_stderr = None
 
         self._dso_modules = self.config.get('httpd', 'dso_modules').split(' ')
         self._mpm_modules = self.config.get('httpd', 'mpm_modules').split(' ')
@@ -320,6 +336,7 @@ class HttpdTestEnv:
                 log_level = "debug"
             else:
                 log_level = "info"
+            log_level = "trace2"
             self._log_interesting = "LogLevel"
             for name in self._httpd_log_modules:
                 self._log_interesting += f" {name}:{log_level}"
@@ -399,6 +416,10 @@ class HttpdTestEnv:
         return self._gen_dir
 
     @property
+    def src_dir(self) -> str:
+        return self._src_dir
+
+    @property
     def test_dir(self) -> str:
         return self._test_dir
 
@@ -458,7 +479,7 @@ class HttpdTestEnv:
 
     @property
     def apachectl_stderr(self):
-        return self._apachectl_stderr
+        return self._httpd_cmd_stderr
 
     def add_cert_specs(self, specs: List[CertificateSpec]):
         self._cert_specs.extend(specs)
@@ -535,14 +556,17 @@ class HttpdTestEnv:
         if not os.path.exists(path):
             return os.makedirs(path)
 
-    def run(self, args, stdout_list=False, intext=None, inbytes=None, debug_log=True):
+    def run(self, args, stdout_list=False, intext=None, inbytes=None, debug_log=True,
+            run_env=None):
+        if not run_env:
+            run_env = os.environ
         if debug_log:
             log.debug(f"run: {args}")
         start = datetime.now()
         if intext is not None:
             inbytes = intext.encode()
         p = subprocess.run(args, stderr=subprocess.PIPE, stdout=subprocess.PIPE,
-                           input=inbytes)
+                           input=inbytes, env=run_env)
         stdout_as_list = None
         if stdout_list:
             try:
@@ -592,10 +616,11 @@ class HttpdTestEnv:
             timeout = timedelta(seconds=5)
         try_until = datetime.now() + timeout
         last_err = ""
+        r = None
         while datetime.now() < try_until:
             # noinspection PyBroadException
             try:
-                r = self.curl_get(url, insecure=True)
+                r = self.curl_get(url, insecure=True, options=['-vvvv'])
                 if r.exit_code == 0:
                     return True
                 time.sleep(.1)
@@ -635,49 +660,68 @@ class HttpdTestEnv:
         log.debug(f"Server still responding after {timeout}")
         return False
 
-    def _run_apachectl(self, cmd) -> ExecResult:
+    def _httpd_cmd(self, cmd) -> ExecResult:
         conf_file = 'stop.conf' if cmd == 'stop' else 'httpd.conf'
-        args = [self._apachectl,
+        env = os.environ.copy()
+        args = [self._httpd,
                 "-d", self.server_dir,
                 "-f", os.path.join(self._server_dir, f'conf/{conf_file}'),
                 "-k", cmd]
-        r = self.run(args)
-        self._apachectl_stderr = r.stderr
+        r = self.run(args, run_env=env)
+        self._httpd_cmd_stderr = r.stderr
         if r.exit_code != 0:
             log.warning(f"failed: {r}")
         return r
 
     def apache_reload(self):
-        r = self._run_apachectl("graceful")
+        r = self._httpd_cmd("graceful")
         if r.exit_code == 0:
             timeout = timedelta(seconds=10)
-            return 0 if self.is_live(self._http_base, timeout=timeout) else -1
+            if self.is_live(self._http_base, timeout=timeout):
+                return 0
+            log.error('failed to reload apache')
+            self._error_log.dump(log)
+            return -1
         return r.exit_code
 
     def apache_restart(self):
-        self.apache_stop()
-        r = self._run_apachectl("start")
+        x = self.apache_stop()
+        if x != 0:
+            return x
+        r = self._httpd_cmd("start")
         if r.exit_code == 0:
             timeout = timedelta(seconds=10)
-            return 0 if self.is_live(self._http_base, timeout=timeout) else -1
+            if self.is_live(self._http_base, timeout=timeout):
+                return 0
+            log.error('failed to reload apache')
+            self._error_log.dump(log)
+            return -1
         return r.exit_code
         
     def apache_stop(self):
-        r = self._run_apachectl("stop")
+        r = self._httpd_cmd("stop")
         if r.exit_code == 0:
             timeout = timedelta(seconds=10)
-            return 0 if self.is_dead(self._http_base, timeout=timeout) else -1
+            if self.is_dead(self._http_base, timeout=timeout):
+                return 0
+            log.error('failed to stop apache')
+            self._error_log.dump(log)
+            return -1
         return r
 
     def apache_graceful_stop(self):
         log.debug("stop apache")
-        self._run_apachectl("graceful-stop")
-        return 0 if self.is_dead() else -1
+        self._httpd_cmd("graceful-stop")
+        if self.is_dead():
+            return 0
+        log.error('failed to gracefully stop apache')
+        self._error_log.dump(log)
+        return -1
 
     def apache_fail(self):
         log.debug("expect apache fail")
-        self._run_apachectl("stop")
-        rv = self._run_apachectl("start")
+        self._httpd_cmd("stop")
+        rv = self._httpd_cmd("start")
         if rv == 0:
             rv = 0 if self.is_dead() else -1
         else:

--- a/test/pyhttpd/log.py
+++ b/test/pyhttpd/log.py
@@ -150,3 +150,7 @@ class HttpdErrorLog:
                     raise TimeoutError(f"pattern not found in error log after {timeout} seconds")
                 time.sleep(.1)
         return False
+
+    def dump(self, logger):
+        for line in open(self.path).readlines():
+            logger.error(f'httpd: {line}')

--- a/test/requirements.txt
+++ b/test/requirements.txt
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+# Copyright 2025 Stefan Eissing (https://dev-icing.de)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+pytest
+cryptography
+filelock
+multipart
+psutil


### PR DESCRIPTION
Adds a workflow on ubuntu-latest. Required some adjustements:
- no longer use `apachectl` and call `httpd/apache2` directly
- add some more debuging when apache start/restart/stop fails