### PR TITLE
md, minor tweaks

### DIFF
--- a/src/md.h
+++ b/src/md.h
@@ -154,6 +154,8 @@ struct md_t {
 #define MD_KEY_HTTPS            "https"
 #define MD_KEY_ID               "id"
 #define MD_KEY_IDENTIFIER       "identifier"
+#define MD_KEY_ISSUER_NAME      "issuer-name"
+#define MD_KEY_ISSUER_URI       "issuer-uri"
 #define MD_KEY_KEY              "key"
 #define MD_KEY_KID              "kid"
 #define MD_KEY_KEYAUTHZ         "keyAuthorization"

--- a/src/md_crypt.c
+++ b/src/md_crypt.c
@@ -1291,6 +1291,18 @@ int md_cert_covers_md(md_cert_t *cert, const md_t *md)
     return 0;
 }
 
+const char *md_cert_get_issuer_name(const md_cert_t *cert, apr_pool_t *p)
+{
+    X509_NAME *xname = X509_get_issuer_name(cert->x509);
+    if(xname) {
+      char *name, *s = X509_NAME_oneline(xname, NULL, 0);
+      name = apr_pstrdup(p, s);
+      OPENSSL_free(s);
+      return name;
+    }
+    return NULL;
+}
+
 apr_status_t md_cert_get_issuers_uri(const char **puri, const md_cert_t *cert, apr_pool_t *p)
 {
     apr_status_t rv = APR_ENOENT;

--- a/src/md_crypt.h
+++ b/src/md_crypt.h
@@ -190,6 +190,7 @@ struct md_timeperiod_t md_cert_get_valid(const md_cert_t *cert);
  */
 int md_certs_are_equal(const md_cert_t *a, const md_cert_t *b);
 
+const char *md_cert_get_issuer_name(const md_cert_t *cert, apr_pool_t *p);
 apr_status_t md_cert_get_issuers_uri(const char **puri, const md_cert_t *cert, apr_pool_t *p);
 apr_status_t md_cert_get_alt_names(apr_array_header_t **pnames, const md_cert_t *cert, apr_pool_t *p);
 

--- a/src/md_reg.c
+++ b/src/md_reg.c
@@ -222,10 +222,15 @@ static apr_status_t state_init(md_reg_t *reg, apr_pool_t *p, md_t *md)
     const md_cert_t *cert;
     const md_pkey_spec_t *spec;
     apr_status_t rv = APR_SUCCESS;
-    int i;
+    int i, is_static = (md->cert_files && md->cert_files->nelts);
 
     if (md->renew_window == NULL) md->renew_window = reg->renew_window;
     if (md->warn_window == NULL) md->warn_window = reg->warn_window;
+
+    if(is_static) {
+      if(md->renew_mode == MD_RENEW_AUTO)
+        md->renew_mode = MD_RENEW_MANUAL;
+    }
 
     if (md->domains && md->domains->pool != p) {
         md_log_perror(MD_LOG_MARK, MD_LOG_ERR, 0, p,

--- a/src/md_status.c
+++ b/src/md_status.c
@@ -47,11 +47,20 @@ static apr_status_t status_get_cert_json(md_json_t **pjson, const md_cert_t *cer
     apr_status_t rv = APR_SUCCESS;
     md_timeperiod_t valid;
     md_json_t *json;
-    
+    const char *issuer_uri, *issuer_name;
+
+
     json = md_json_create(p);
+    issuer_name = md_cert_get_issuer_name(cert, p);
+    if (issuer_name)
+      md_json_sets(issuer_name, json, MD_KEY_ISSUER_NAME, NULL);
+    rv = md_cert_get_issuers_uri(&issuer_uri, cert, p);
+    if(rv == APR_SUCCESS && issuer_uri)
+      md_json_sets(issuer_uri, json, MD_KEY_ISSUER_URI, NULL);
     valid.start = md_cert_get_not_before(cert);
     valid.end = md_cert_get_not_after(cert);
     md_json_set_timeperiod(&valid, json, MD_KEY_VALID, NULL);
+    md_json_sets(md_cert_get_serial_number(cert, p), json, MD_KEY_SERIAL, NULL);
     md_json_sets(md_cert_get_serial_number(cert, p), json, MD_KEY_SERIAL, NULL);
     if (APR_SUCCESS != (rv = md_cert_to_sha256_fingerprint(&finger, cert, p))) goto leave;
     md_json_sets(finger, json, MD_KEY_SHA256_FINGERPRINT, NULL);

--- a/test/modules/md/test_920_status.py
+++ b/test/modules/md/test_920_status.py
@@ -214,7 +214,7 @@ Protocols h2 http/1.1 acme-tls/1
         assert 'renewal' not in status
         print(status)
         assert status['state'] == env.MD_S_COMPLETE
-        assert status['renew-mode'] == 1  # manual
+        assert status['renew-mode'] == 0  # manual
 
     # MD with 2 certificates
     def test_md_920_020(self, env):


### PR DESCRIPTION
- in md_status json, output also issue name and uris for certificates
- in mds with static certificates, force renew-mode from auto to manual to make clear that this md is not renewing unless set to 'always'.