### PR TITLE
ACME profile support

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -37,6 +37,7 @@ permissions: {}
 env:
   MARGS: "-j5"
   CFLAGS: "-g"
+  pebble-version: v2.7.0
 
 jobs:
   linux:
@@ -76,7 +77,7 @@ jobs:
         if: contains(matrix.build.install_steps, 'pebble')
         run: |
           export PATH=$PATH:$HOME/go/bin
-          git clone --quiet --depth=1 https://github.com/letsencrypt/pebble/
+          git clone --quiet --depth=1 -b ${{ env.pebble-version }} https://github.com/letsencrypt/pebble/
           cd pebble
           go install ./cmd/pebble
           go install ./cmd/pebble-challtestsrv

--- a/src/md.h
+++ b/src/md.h
@@ -92,6 +92,8 @@ struct md_t {
     struct apr_array_header_t *pkey_files; /* != NULL iff privkeys explicitly configured */
     const char *ca_eab_kid;         /* optional KEYID for external account binding */
     const char *ca_eab_hmac;        /* optional HMAC for external account binding */
+    const char *profile;            /* optional cert profile to order */
+    int profile_mandatory;          /* if profile, when given, is mandatory */
 
     const char *state_descr;        /* description of state of NULL */
     
@@ -177,6 +179,8 @@ struct md_t {
 #define MD_KEY_PKEY             "privkey"
 #define MD_KEY_PKEY_FILES       "pkey-files"
 #define MD_KEY_PROBLEM          "problem"
+#define MD_KEY_PROFILE          "profile"
+#define MD_KEY_PROFILE_MANDATORY "profile-mandatory"
 #define MD_KEY_PROTO            "proto"
 #define MD_KEY_READY            "ready"
 #define MD_KEY_REGISTRATION     "registration"

--- a/src/md_acme.h
+++ b/src/md_acme.h
@@ -118,6 +118,7 @@ struct md_acme_t {
             const char *key_change;
             const char *revoke_cert;
             const char *new_nonce;
+            struct apr_array_header_t *profiles;
         } v2;
     } api;
     const char *ca_agreement;

--- a/src/md_acme_drive.c
+++ b/src/md_acme_drive.c
@@ -765,7 +765,9 @@ static apr_status_t acme_renew(md_proto_driver_t *d, md_result_t *result)
     if (!ad->domains) {
         ad->domains = md_dns_make_minimal(d->p, ad->md->domains);
     }
-    
+    ad->profile = ad->md->profile;
+    ad->profile_mandatory = ad->md->profile_mandatory;
+
     md_result_activity_printf(result, "Contacting ACME server for %s at %s",
                               d->md->name, ca_effective);
     if (APR_SUCCESS != (rv = md_acme_create(&ad->acme, d->p, ca_effective,

--- a/src/md_acme_drive.h
+++ b/src/md_acme_drive.h
@@ -29,6 +29,8 @@ typedef struct md_acme_driver_t {
     md_t *md;
     struct apr_array_header_t *domains;
     apr_array_header_t *ca_challenges;
+    const char *profile;
+    int profile_mandatory;
     
     int complete;
     apr_array_header_t *creds;       /* the new md_credentials_t */

--- a/src/md_acme_order.h
+++ b/src/md_acme_order.h
@@ -76,7 +76,8 @@ apr_status_t md_acme_order_monitor_authzs(md_acme_order_t *order, md_acme_t *acm
 /* ACMEv2 only ************************************************************************************/
 
 apr_status_t md_acme_order_register(md_acme_order_t **porder, md_acme_t *acme, apr_pool_t *p, 
-                                    const char *name, struct apr_array_header_t *domains);
+                                    const char *name, struct apr_array_header_t *domains,
+                                    const char *profile);
 
 apr_status_t md_acme_order_update(md_acme_order_t *order, md_acme_t *acme, 
                                   struct md_result_t *result, apr_pool_t *p);

--- a/src/md_core.c
+++ b/src/md_core.c
@@ -317,6 +317,8 @@ md_json_t *md_to_json(const md_t *md, apr_pool_t *p)
             md_json_sets(md->ca_eab_kid, json, MD_KEY_EAB, MD_KEY_KID, NULL);
             if (md->ca_eab_hmac) md_json_sets(md->ca_eab_hmac, json, MD_KEY_EAB, MD_KEY_HMAC, NULL);
         }
+        if (md->profile) md_json_sets(md->profile, json, MD_KEY_PROFILE, NULL);
+        md_json_setb(md->profile_mandatory > 0, json, MD_KEY_PROFILE_MANDATORY, NULL);
         return json;
     }
     return NULL;
@@ -383,6 +385,10 @@ md_t *md_from_json(md_json_t *json, apr_pool_t *p)
             md->ca_eab_kid = md_json_dups(p, json, MD_KEY_EAB, MD_KEY_KID, NULL);
             md->ca_eab_hmac = md_json_dups(p, json, MD_KEY_EAB, MD_KEY_HMAC, NULL);
         }
+
+        md->profile_mandatory = (int)md_json_getb(json, MD_KEY_PROFILE_MANDATORY, NULL);
+        if (md_json_has_key(json, MD_KEY_PROFILE, NULL))
+            md->profile = md_json_dups(p, json, MD_KEY_PROFILE, NULL);
         return md;
     }
     return NULL;

--- a/src/mod_md.c
+++ b/src/mod_md.c
@@ -363,6 +363,12 @@ static void merge_srv_config(md_t *md, md_srv_conf_t *base_sc, apr_pool_t *p)
     if (md->stapling < 0) {
         md->stapling = md_config_geti(md->sc, MD_CONFIG_STAPLING);
     }
+    if (!md->profile) {
+        md->profile = md_config_gets(md->sc, MD_CONFIG_CA_PROFILE);
+    }
+    if (md->profile_mandatory < 0) {
+        md->profile_mandatory = md_config_geti(md->sc, MD_CONFIG_CA_PROFILE_MANDATORY);
+    }
 }
 
 static apr_status_t check_coverage(md_t *md, const char *domain, server_rec *s,

--- a/src/mod_md_config.h
+++ b/src/mod_md_config.h
@@ -39,6 +39,8 @@ typedef enum {
     MD_CONFIG_MESSGE_CMD,
     MD_CONFIG_STAPLING,
     MD_CONFIG_STAPLE_OTHERS,
+    MD_CONFIG_CA_PROFILE,
+    MD_CONFIG_CA_PROFILE_MANDATORY,
 } md_config_var_t;
 
 typedef enum {
@@ -103,6 +105,8 @@ typedef struct md_srv_conf_t {
     struct apr_array_header_t *ca_challenges; /* challenge types configured */
     const char *ca_eab_kid;            /* != NULL, external account binding keyid */
     const char *ca_eab_hmac;           /* != NULL, external account binding hmac */
+    const char *profile;               /* != NULL, ACME order profile */
+    int profile_mandatory;             /* if ACME profile, when set, is mandatory */
 
     int stapling;                      /* OCSP stapling enabled */
     int staple_others;                 /* Provide OCSP stapling for non-MD certificates */

--- a/test/modules/md/pebble/pebble-eab.json.template
+++ b/test/modules/md/pebble/pebble-eab.json.template
@@ -11,6 +11,16 @@
     "externalAccountMACKeys": {
       "kid-1": "zWNDZM6eQGHWpSRTPal5eIUYFTu7EajVIoguysqZ9wG44nMEtx3MUAsUDkMTQ12W",
       "kid-2": "b10lLJs8l1GPIzsLP0s6pMt8O0XVGnfTaCeROxQM0BIt2XrJMDHJZBM5NuQmQJQH"
-    }
+    },
+    "profiles": {
+       "default": {
+         "description": "The profile you know and love",
+         "validityPeriod": 7776000
+       },
+       "shortlived": {
+         "description": "A short-lived cert profile, without actual enforcement",
+         "validityPeriod": 518400
+       }
+     }
   }
 }

--- a/test/modules/md/pebble/pebble.json.template
+++ b/test/modules/md/pebble/pebble.json.template
@@ -7,6 +7,21 @@
     "httpPort": ${http_port},
     "tlsPort": ${https_port},
     "ocspResponderURL": "",
-    "externalAccountBindingRequired": false
+    "externalAccountBindingRequired": false,
+    "domainBlocklist": ["blocked-domain.example"],
+    "retryAfter": {
+        "authz": 3,
+        "order": 5
+    },
+    "profiles": {
+       "default": {
+         "description": "The profile you know and love",
+         "validityPeriod": 7776000
+       },
+       "shortlived": {
+         "description": "A short-lived cert profile, without actual enforcement",
+         "validityPeriod": 518400
+       }
+     }
   }
 }

--- a/test/modules/md/test_710_profiles.py
+++ b/test/modules/md/test_710_profiles.py
@@ -1,0 +1,124 @@
+import datetime
+import email.utils
+import os
+from datetime import timedelta
+
+import pytest
+from pyhttpd.certs import CertificateSpec
+
+from pyhttpd.env import HttpdTestEnv
+from .md_cert_util import MDCertUtil
+from .md_env import MDTestEnv
+from .md_conf import MDConf
+
+
+@pytest.mark.skipif(condition=not MDTestEnv.has_acme_server(),
+                    reason="no ACME test server configured")
+class TestProfiles:
+
+    @pytest.fixture(autouse=True, scope='class')
+    def _class_scope(self, env, acme):
+        env.APACHE_CONF_SRC = "data/test_auto"
+        acme.start(config='default')
+        env.check_acme()
+        env.clear_store()
+        MDConf(env).install()
+        assert env.apache_restart() == 0, f'{env.apachectl_stderr}'
+
+    @pytest.fixture(autouse=True, scope='function')
+    def _method_scope(self, env, request):
+        env.clear_store()
+        self.test_domain = env.get_request_domain(request)
+
+    def _write_res_file(self, doc_root, name, content):
+        if not os.path.exists(doc_root):
+            os.makedirs(doc_root)
+        open(os.path.join(doc_root, name), "w").write(content)
+
+    # create a MD with 'default' profile, get cert
+    def test_md_710_001(self, env):
+        domain = self.test_domain
+        # generate config with one MD
+        domains = [domain, "www." + domain]
+        conf = MDConf(env, admin="admin@" + domain)
+        conf.add_drive_mode("auto")
+        conf.start_md(domains)
+        conf.add(f'  MDProfile default')
+        conf.end_md()
+        conf.add_vhost(domains)
+        conf.install()
+        #
+        assert env.apache_restart() == 0, f'{env.apachectl_stderr}'
+        assert env.await_completion(domains)
+        stat = env.get_md_status(domain)
+        assert stat["watched"] == 1
+        assert stat["profile"] == "default", f'{stat}'
+        assert stat['cert']['rsa']['valid']['until'], f'{stat}'
+        ts = email.utils.parsedate_to_datetime(stat['cert']['rsa']['valid']['until'])
+        valid = ts - datetime.datetime.now(datetime.UTC)
+        assert valid.days in [89, 90]
+
+    # create a MD with 'shortlived' profile, get cert
+    def test_md_710_002(self, env):
+        domain = self.test_domain
+        # generate config with one MD
+        domains = [domain, "www." + domain]
+        conf = MDConf(env, admin="admin@" + domain)
+        conf.add_drive_mode("auto")
+        conf.start_md(domains)
+        conf.add(f'  MDProfile shortlived')
+        conf.end_md()
+        conf.add_vhost(domains)
+        conf.install()
+        #
+        assert env.apache_restart() == 0, f'{env.apachectl_stderr}'
+        assert env.await_completion(domains)
+        stat = env.get_md_status(domain)
+        assert stat["watched"] == 1
+        assert stat["profile"] == "shortlived", f'{stat}'
+        assert stat['cert']['rsa']['valid']['until'], f'{stat}'
+        ts = email.utils.parsedate_to_datetime(stat['cert']['rsa']['valid']['until'])
+        valid = ts - datetime.datetime.now(datetime.UTC)
+        assert valid.days in [5, 6]
+
+    # create a MD with unknown 'XXX' profile, get cert
+    def test_md_710_003(self, env):
+        domain = self.test_domain
+        # generate config with one MD
+        domains = [domain, "www." + domain]
+        conf = MDConf(env, admin="admin@" + domain)
+        conf.add_drive_mode("auto")
+        conf.start_md(domains)
+        conf.add(f'  MDProfile XXX')
+        conf.end_md()
+        conf.add_vhost(domains)
+        conf.install()
+        #
+        assert env.apache_restart() == 0, f'{env.apachectl_stderr}'
+        assert env.await_completion(domains)
+        stat = env.get_md_status(domain)
+        assert stat["watched"] == 1
+        assert stat["profile"] == "XXX", f'{stat}'
+
+    # create a MD with unknown 'XXX' profile, mandatory, fail
+    def test_md_710_004(self, env):
+        domain = self.test_domain
+        # generate config with one MD
+        domains = [domain, "www." + domain]
+        conf = MDConf(env, admin="admin@" + domain)
+        conf.add_drive_mode("auto")
+        conf.start_md(domains)
+        conf.add(f'  MDProfile XXX')
+        conf.add(f'  MDProfileMandatory on')
+        conf.end_md()
+        conf.add_vhost(domains)
+        conf.install()
+        #
+        assert env.apache_restart() == 0, f'{env.apachectl_stderr}'
+        assert env.await_error(domain)
+        stat = env.get_md_status(domain)
+        assert stat["watched"] == 1
+        assert stat["profile"] == "XXX", f'{stat}'
+        assert len(stat['cert']) == 0, f'{stat}'
+        assert stat['renewal']['errors'] > 0, f'{stat}'
+        assert stat['renewal']['last']['activity'] == 'Creating new order', f'{stat}'


### PR DESCRIPTION
- add directives `MDProfile` and `MDProfileMandatory`
- check ACME directory resource for available profiles
- select profile when supported
- fail profile if mandatory and not supported
- add test cases test_710 and pebble v2.7.0 to verify
- fix reliabilty of test_702_009 while we are here