### PR TITLE
Handling of corrupted files in store

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,8 @@
+ * Fixed handling of corrupted httpd.json and added test 300_30 for it.
+   File is removed on error and written again. Fixes #369.
+ * Added explanation in log for how to proceed when md_store.json could not be
+   parsed and prevented the server start.
+
 v2.5.0
 ----------------------------------------------------------------------------------------------------
  * Added support for ACME profiles. See README on how to use them.

--- a/src/md_reg.c
+++ b/src/md_reg.c
@@ -81,6 +81,18 @@ static apr_status_t load_props(md_reg_t *reg, apr_pool_t *p)
     else if (APR_STATUS_IS_ENOENT(rv)) {
         rv = APR_SUCCESS;
     }
+    else {
+        apr_status_t rv2;
+        md_log_perror(MD_LOG_MARK, MD_LOG_INFO, 0, p,
+                      "removing md/%s on error loading it", MD_FN_HTTPD_JSON);
+        rv2 = md_store_remove(reg->store, MD_SG_NONE, NULL, MD_FN_HTTPD_JSON,
+                              p, TRUE);
+        if (rv2 != APR_SUCCESS)
+          md_log_perror(MD_LOG_MARK, MD_LOG_ERR, APR_EINVAL, p,
+                        "error removing md/%s", MD_FN_HTTPD_JSON);
+        else
+          rv = APR_SUCCESS;
+    }
     return rv;
 }
 

--- a/src/md_store_fs.c
+++ b/src/md_store_fs.c
@@ -275,6 +275,15 @@ static apr_status_t setup_store_file(void *baton, apr_pool_t *p, apr_pool_t *pte
 read:
     if (MD_OK(md_util_is_file(fname, ptemp))) {
         rv = read_store_file(s_fs, fname, p, ptemp);
+        if (rv != APR_SUCCESS) {
+            md_log_perror(MD_LOG_MARK, MD_LOG_ERR, rv, p,
+            "The central store file md/md_store.json seems to exist, but "
+            "its content are not readable as JSON. Either it got somehow corrupted "
+            "or the store directory was configured for a location with a foreign "
+            "md_store.json file. Either way, it is unclear how to proceeed. "
+            "You should either restore the correct file/location or clean the directory "
+            "so it gets initialized again.");
+        }
     }
     else if (APR_STATUS_IS_ENOENT(rv)
         && APR_STATUS_IS_EEXIST(rv = init_store_file(s_fs, fname, p, ptemp))) {

--- a/src/mod_md.c
+++ b/src/mod_md.c
@@ -951,7 +951,8 @@ static apr_status_t md_post_config_before_ssl(apr_pool_t *p, apr_pool_t *plog,
     /*5*/
     md_reg_load_stagings(mc->reg, mc->mds, mc->env, p);
 leave:
-    md_reg_unlock_global(mc->reg, ptemp);
+    if (mc->reg)
+        md_reg_unlock_global(mc->reg, ptemp);
     return rv;
 }
 


### PR DESCRIPTION
 * Fixed handling of corrupted httpd.json and added test 300_30 for it. File is removed on error and written again. Fixes #369.
 * Added explanation in log for how to proceed when md_store.json could not be parsed and prevented the server start.