### PR TITLE
Tweaking `MDRetryDelay`

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,10 @@
+ * Increasing default `MDRetryDelay` to 30 seconds to generate less bursty
+   traffic on errored renewals for the ACME CA. This leads to error retries
+   of 30s, 1 minute, 2, 4, etc. up to daily attempts.
+ * Checking that configuring `MDRetryDelay` will result in a positive
+   duration. A delay of 0 is not accepted.
+ * Fix a bug in checking Content-Type of responses from the ACME server.
+
 v2.6.0
 ----------------------------------------------------------------------------------------------------
  * Added ACME ARI support (rfc9773) to the module. Enabled by default. New

--- a/README.md
+++ b/README.md
@@ -2414,7 +2414,7 @@ files as usual.
 
 ## MDRetryDelay
 `MDRetryDelay duration`
-Default: 5s
+Default: 30s
 
 The delay on a failed renewal before the next attempt is done. This doubles on every consecutive error with a
 cap of 24 hours, e.g. daily retries. Furthermore, the effective delay is randomly jiggled by +-50%. This is

--- a/src/md_cmd_main.c
+++ b/src/md_cmd_main.c
@@ -186,7 +186,7 @@ static apr_status_t cmd_process(md_cmd_ctx *ctx, const md_cmd_t *cmd)
         }
         if (APR_SUCCESS != (rv = md_reg_create(&ctx->reg, ctx->p, ctx->store,
                                                md_cmd_ctx_get_option(ctx, MD_CMD_OPT_PROXY_URL),
-                                               ctx->ca_file, apr_time_from_sec(2), 10,
+                                               ctx->ca_file, apr_time_from_sec(15), 10,
                                                0, apr_time_from_sec(5)))) {
             fprintf(stderr, "error %d creating registry from store: %s\n", rv, ctx->base_dir);
             return APR_EINVAL;

--- a/src/md_json.c
+++ b/src/md_json.c
@@ -1186,12 +1186,15 @@ apr_status_t md_json_read_http(md_json_t **pjson, apr_pool_t *pool, const md_htt
 {
     apr_status_t rv = APR_ENOENT;
     const char *ctype, *p;
+    apr_size_t ctype_len;
 
     *pjson = NULL;
     if (!res->body) goto cleanup;
     ctype = md_util_parse_ct(res->req->pool, apr_table_get(res->headers, "content-type"));
     if (!ctype) goto cleanup;
-    p = ctype + strlen(ctype) +1;
+    ctype_len = strlen(ctype);
+    if (ctype_len < sizeof("/json")) goto cleanup;
+    p = ctype + ctype_len + 1; /* point to the terminating 0 */
     if (!strcmp(p - sizeof("/json"), "/json") ||
         !strcmp(p - sizeof("+json"), "+json") ||
         !strcmp(ctype, "text/plain")) {

--- a/src/mod_md_config.c
+++ b/src/mod_md_config.c
@@ -85,7 +85,7 @@ static md_mod_conf_t defmc = {
     "https://crt.sh?q=",       /* default cert checker site url */
     NULL,                      /* CA cert file to use */
     apr_time_from_sec(MD_SECS_PER_DAY/2), /* default time between cert checks */
-    apr_time_from_sec(5),      /* minimum delay for retries */
+    apr_time_from_sec(30),     /* minimum delay for retries */
     13,                        /* retry_failover after 14 errors, with 5s delay ~ half a day */
     0,                         /* store locks, disabled by default */
     apr_time_from_sec(5),      /* max time to wait to obaint a store lock */
@@ -704,6 +704,9 @@ static const char *md_config_set_min_delay(cmd_parms *cmd, void *dc, const char 
     if (err) return err;
     if (md_duration_parse(&delay, value, "s") != APR_SUCCESS) {
         return "unrecognized duration format";
+    }
+    if (delay <= 0) {
+        return "minimum delay must be greater than 0";
     }
     config->mc->min_delay = delay;
     return NULL;


### PR DESCRIPTION
* Increasing default MDRetryDelay to 30 seconds to generate less bursty traffic on errored renewals for the ACME CA. This leads to error retries of 30s, 1 minute, 2, 4, etc. up to daily attempts.
 * Checking that configuring `MDRetryDelay` will result in a positive duration. A delay of 0 is not accepted.
 * Fix a bug in checking Content-Type of responses from the ACME server.