### PR TITLE
fix error delay calculation

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,6 @@
+ * Fix error retry delay calculation to not already doubling the wait
+   on the first error.
+
 v2.6.1
 ----------------------------------------------------------------------------------------------------
  * Increasing default `MDRetryDelay` to 30 seconds to generate less bursty

--- a/src/md_status.c
+++ b/src/md_status.c
@@ -616,15 +616,13 @@ apr_time_t md_job_delay_on_errors(md_job_t *job, int err_count, const char *last
          * As apr_time_t is signed, this might wrap around*/
         int i;
         delay = job->min_delay;
-        for (i = 0; i < err_count; ++i) {
+        for (i = 0; i < (err_count - 1); ++i) {
           delay <<= 1;
           if ((delay <= 0) || (delay > max_delay)) {
               delay = max_delay;
               break;
           }
         }
-        if (delay > max_delay)
-            delay = max_delay;
     }
     if (delay > 0) {
         /* jitter the delay by +/- 0-50%.


### PR DESCRIPTION
the recent change led to the doubling of the delay already on the first error. Fix that.