### PR TITLE
New directive "MDInitialDelay"

### DIFF
--- a/README.md
+++ b/README.md
@@ -1781,7 +1781,7 @@ checks by mod_md in v1.1.x which are now eliminated. If you have many domains, t
 * [MDChallengeDns01](#mdchallengedns01)
 * [MDChallengeDns01Version](#mdchallengedns01version)
 * [MDExternalAccountBinding](#mdexternalaccountbinding)
-* [MDRenewMode](#mdrenewmode--renew-mode)
+* [MDInitialDelay](#mdinitialdelay)
 * [MDMatchNames](#mdmatchnames)
 * [MDMember](#mdmember)
 * [MDMembers](#mdmembers)
@@ -1794,8 +1794,10 @@ checks by mod_md in v1.1.x which are now eliminated. If you have many domains, t
 * [MDProfileMandatory](#mdprofilemandatory)
 * [MDHttpProxy](#mdhttpproxy)
 * [MDRenewViaARI](#mdrenewviaari)
+* [MDRenewMode](#mdrenewmode--renew-mode)
 * [MDRenewWindow](#mdrenewwindow--when-to-renew)
 * [MDRequireHttps](#mdrequirehttps)
+* [MDRetryDelay](#mdretrydelay)
 * [MDRetryFailover](#mdretryfailover)
 * [MDWarnWindow](#mdwarnwindow--when-to-warn)
 * [MDServerStatus](#mdserverstatus)
@@ -2411,6 +2413,13 @@ format and would look like this:
 
 Make the file readable for root only (or what the httpd starts with) and handle your configuration
 files as usual.
+
+## MDInitialDelay
+`MDInitialDelay duration`
+Default: 0
+
+How long to delay the first certificate check.
+By default, it occurs immediately after the server start.
 
 ## MDRetryDelay
 `MDRetryDelay duration`

--- a/src/mod_md_config.h
+++ b/src/mod_md_config.h
@@ -78,6 +78,7 @@ struct md_mod_conf_t {
     const char *cert_check_name;       /* name of the linked certificate check site */
     const char *cert_check_url;        /* url "template for" checking a certificate */
     const char *ca_certs;              /* root certificates to use for connections */
+    apr_time_t initial_delay;          /* how long to delay the first cert renewal check */
     apr_time_t check_interval;         /* duration between cert renewal checks */
     apr_time_t min_delay;              /* minimum delay for retries */
     int retry_failover;                /* number of errors to trigger CA failover */

--- a/src/mod_md_drive.c
+++ b/src/mod_md_drive.c
@@ -403,7 +403,7 @@ apr_status_t md_renew_start_watching(md_mod_conf_t *mc, server_rec *s, apr_pool_
                      "create md renew watchdog(%s)", MD_RENEW_WATCHDOG_NAME);
         return rv;
     }
-    rv = wd_register_callback(dctx->watchdog, 0, dctx, run_watchdog);
+    rv = wd_register_callback(dctx->watchdog, mc->initial_delay, dctx, run_watchdog);
     ap_log_error(APLOG_MARK, rv? APLOG_CRIT : APLOG_DEBUG, rv, s, APLOGNO(10067) 
                  "register md renew watchdog(%s)", MD_RENEW_WATCHDOG_NAME);
     return rv;


### PR DESCRIPTION
Delay the first certificate check after server startup by a configurable amount of time.

The default is 0 (no delay).