### PR TITLE
md_curl: reset curl handle before reusing it

### DIFF
--- a/src/md_curl.c
+++ b/src/md_curl.c
@@ -255,16 +255,18 @@ static apr_status_t internals_setup(md_http_request_t *req)
             rv = APR_EGENERAL;
             goto leave;
         }
-        curl_easy_setopt(curl, CURLOPT_HEADERFUNCTION, header_cb);
-        curl_easy_setopt(curl, CURLOPT_HEADERDATA, NULL);
-        curl_easy_setopt(curl, CURLOPT_READFUNCTION, req_data_cb);
-        curl_easy_setopt(curl, CURLOPT_READDATA, NULL);
-        curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, resp_data_cb);
-        curl_easy_setopt(curl, CURLOPT_WRITEDATA, NULL);
     }
     else {
         md_log_perror(MD_LOG_MARK, MD_LOG_TRACE3, 0, req->pool, "reusing curl instance from http");
+        curl_easy_reset(curl);
     }
+
+    curl_easy_setopt(curl, CURLOPT_HEADERFUNCTION, header_cb);
+    curl_easy_setopt(curl, CURLOPT_HEADERDATA, NULL);
+    curl_easy_setopt(curl, CURLOPT_READFUNCTION, req_data_cb);
+    curl_easy_setopt(curl, CURLOPT_READDATA, NULL);
+    curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, resp_data_cb);
+    curl_easy_setopt(curl, CURLOPT_WRITEDATA, NULL);
 
     internals = apr_pcalloc(req->pool, sizeof(*internals));
     internals->curl = curl;


### PR DESCRIPTION
I'm analyzing a core dump that I got from a customer, the crash happens in libcurl when setting custom HTTP headers. I have reviewed the code, maybe the bug is that mod_md reuses curl handles without resetting them.

I assume that `CURLOPT_HTTPHEADER` from a previous request has been reused, but it now points to freed or overwritten memory.

This is just a theory, please review carefully, maybe I'm overlooking something...