### PR TITLE
Fix a small memory leak when using OpenSSL's BIGNUMs. [Theo Buehler]

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,5 @@
+ * Fix a small memory leak when using OpenSSL's BIGNUMs. [Theo Buehler]
+
 v2.6.5
 ----------------------------------------------------------------------------------------------------
  * Hardening: when build with OpenSSL older than 1.0.2 or old libressl versions,

--- a/src/md_crypt.c
+++ b/src/md_crypt.c
@@ -1244,7 +1244,7 @@ const char *md_cert_get_serial_number(const md_cert_t *cert, apr_pool_t *p)
         serial = BN_bn2hex(bn);
         s = apr_pstrdup(p, serial);
         OPENSSL_free((void*)serial);
-        OPENSSL_free((void*)bn);
+        BN_free(bn);
     }
     return s;
 }
@@ -2254,7 +2254,7 @@ apr_status_t md_cert_get_ari_cert_id(const char **pari_cert_id,
     memset(&ser_buf, 0, sizeof(ser_buf));
     bn = ASN1_INTEGER_to_BN(serial, NULL);
     sder_len = BN_bn2bin(bn, sbuf);
-    OPENSSL_free((void*)bn);
+    BN_free(bn);
     if (sder_len < 1)
         return APR_EINVAL;
     ser_buf.len = (apr_size_t)sder_len;

--- a/src/md_ocsp.c
+++ b/src/md_ocsp.c
@@ -532,7 +532,7 @@ static const char *certid_summary(const OCSP_CERTID *certid, apr_pool_t *p)
         bn = ASN1_INTEGER_to_BN(aserial, NULL);
         s = BN_bn2hex(bn);
         serial = apr_pstrdup(p, s);
-        OPENSSL_free((void*)bn);
+        BN_free(bn);
         OPENSSL_free((void*)s);
     }
     return apr_psprintf(p, "certid[der=%s, issuer=%s, key=%s, serial=%s]",


### PR DESCRIPTION
Via https://github.com/apache/httpd/pull/578