### PR TITLE
Implement separate storage directories for state and runtime storage

### DIFF
--- a/src/md_cmd.h
+++ b/src/md_cmd.h
@@ -34,6 +34,7 @@ struct md_cmd_ctx {
     apr_pool_t *p;
     
     const char *base_dir;
+    const char *cache_dir;
     const char *ca_url;
     const char *ca_file;
     struct apr_table_t *env;

--- a/src/md_cmd_main.c
+++ b/src/md_cmd_main.c
@@ -174,7 +174,7 @@ static apr_status_t cmd_process(md_cmd_ctx *ctx, const md_cmd_t *cmd)
             fprintf(stderr, "need store directory for command: %s\n", cmd->name);
             return APR_EINVAL;
         }
-        if (APR_SUCCESS != (rv = md_store_fs_init(&ctx->store, ctx->p, ctx->base_dir))) {
+        if (APR_SUCCESS != (rv = md_store_fs_init(&ctx->store, ctx->p, ctx->base_dir, ctx->cache_dir))) {
             fprintf(stderr, "error %d creating store for: %s\n", rv, ctx->base_dir);
             return APR_EINVAL;
         }

--- a/src/md_store.h
+++ b/src/md_store.h
@@ -71,6 +71,9 @@ typedef enum {
     MD_SG_COUNT,        /* number of storage groups, used in setups */
 } md_store_group_t;
 
+/* Test whether group is supposed to be in the ephemeral cache directory */
+#define MD_SG_CACHE(group) ((group == MD_SG_CHALLENGES) || (group == MD_SG_STAGING) || (group == MD_SG_TMP) || (group == MD_SG_OCSP))
+
 #define MD_FN_MD                "md.json"
 #define MD_FN_JOB               "job.json"
 #define MD_FN_HTTPD_JSON        "httpd.json"

--- a/src/md_store_fs.h
+++ b/src/md_store_fs.h
@@ -39,7 +39,7 @@ struct md_store_t;
 #define MD_FPROT_D_UALL_WREAD (MD_FPROT_D_UALL_GREAD|APR_FPROT_WREAD|APR_FPROT_WEXECUTE)
 
 apr_status_t md_store_fs_init(struct md_store_t **pstore, apr_pool_t *p, 
-                              const char *path);
+                              const char *store_path, const char *cache_path);
 
 
 apr_status_t md_store_fs_default_perms_set(struct md_store_t *store, 

--- a/src/mod_md.c
+++ b/src/mod_md.c
@@ -277,10 +277,11 @@ static apr_status_t check_group_dir(md_store_t *store, md_store_group_t group,
 static apr_status_t setup_store(md_store_t **pstore, md_mod_conf_t *mc,
                                 apr_pool_t *p, server_rec *s)
 {
-    const char *base_dir;
+    const char *base_dir, *cache_dir;
     apr_status_t rv;
 
     base_dir = ap_server_root_relative(p, mc->base_dir);
+    cache_dir = ap_server_root_relative(p, mc->cache_dir);
 
     if (APR_SUCCESS != (rv = md_store_fs_init(pstore, p, base_dir))) {
         ap_log_error(APLOG_MARK, APLOG_ERR, rv, s, APLOGNO(10046)"setup store for %s", base_dir);

--- a/src/mod_md.c
+++ b/src/mod_md.c
@@ -283,7 +283,7 @@ static apr_status_t setup_store(md_store_t **pstore, md_mod_conf_t *mc,
     base_dir = ap_server_root_relative(p, mc->base_dir);
     cache_dir = ap_server_root_relative(p, mc->cache_dir);
 
-    if (APR_SUCCESS != (rv = md_store_fs_init(pstore, p, base_dir))) {
+    if (APR_SUCCESS != (rv = md_store_fs_init(pstore, p, base_dir, cache_dir))) {
         ap_log_error(APLOG_MARK, APLOG_ERR, rv, s, APLOGNO(10046)"setup store for %s", base_dir);
         goto leave;
     }
@@ -1598,4 +1598,3 @@ static void md_hooks(apr_pool_t *pool)
 #error "This version of mod_md requires Apache httpd 2.4.48 or newer."
 #endif /* AP_MODULE_MAGIC_AT_LEAST() */
 }
-

--- a/src/mod_md_config.h
+++ b/src/mod_md_config.h
@@ -27,6 +27,7 @@ typedef enum {
     MD_CONFIG_CA_CONTACT,
     MD_CONFIG_CA_PROTO,
     MD_CONFIG_BASE_DIR,
+    MD_CONFIG_CACHE_DIR,
     MD_CONFIG_CA_AGREEMENT,
     MD_CONFIG_DRIVE_MODE,
     MD_CONFIG_RENEW_WINDOW,
@@ -53,6 +54,7 @@ typedef struct md_mod_conf_t md_mod_conf_t;
 struct md_mod_conf_t {
     apr_array_header_t *mds;           /* all md_t* defined in the config, shared */
     const char *base_dir;              /* base dir for store */
+    const char *cache_dir;             /* base dir for cache */
     const char *proxy_url;             /* proxy url to use (or NULL) */
     struct md_reg_t *reg;              /* md registry instance */
     struct md_ocsp_reg_t *ocsp;        /* ocsp status registry */


### PR DESCRIPTION
**Very much work in progress!**

State storage is e.g. ACME account data as well as live and archived certificate data.
Runtime storage is e.g. ACME challenges.

Closes: #402 