### PR TITLE
Check whether the "type" key in error responses is present

### DIFF
--- a/src/md_acme.c
+++ b/src/md_acme.c
@@ -182,22 +182,24 @@ static apr_status_t inspect_problem(md_acme_req_t *req, const md_http_response_t
             
             req->resp_json = problem;
             ptype = md_json_gets(problem, MD_KEY_TYPE, NULL); 
-            pdetail = md_json_gets(problem, MD_KEY_DETAIL, NULL);
-            req->rv = problem_status_get(ptype);
-            md_result_problem_set(req->result, req->rv, ptype, pdetail,
-                                  md_json_getj(problem, MD_KEY_SUBPROBLEMS, NULL));
-            
-            
-            
-            if (APR_STATUS_IS_EAGAIN(req->rv)) {
-                md_log_perror(MD_LOG_MARK, MD_LOG_DEBUG, req->rv, req->p,
-                              "acme reports %s: %s", ptype, pdetail);
+
+            if (ptype) {
+                req->rv = problem_status_get(ptype);
+                pdetail = md_json_gets(problem, MD_KEY_DETAIL, NULL);
+
+                md_result_problem_set(req->result, req->rv, ptype, pdetail,
+                                      md_json_getj(problem, MD_KEY_SUBPROBLEMS, NULL));
+
+                if (APR_STATUS_IS_EAGAIN(req->rv)) {
+                    md_log_perror(MD_LOG_MARK, MD_LOG_DEBUG, req->rv, req->p,
+                                  "acme reports %s: %s", ptype, pdetail);
+                }
+                else {
+                    md_log_perror(MD_LOG_MARK, MD_LOG_WARNING, req->rv, req->p,
+                                  "acme problem %s: %s", ptype, pdetail);
+                }
+                return req->rv;
             }
-            else {
-                md_log_perror(MD_LOG_MARK, MD_LOG_WARNING, req->rv, req->p,
-                              "acme problem %s: %s", ptype, pdetail);
-            }
-            return req->rv;
         }
     }
     


### PR DESCRIPTION
mod_md crashes when processing a JSON error response that does not have a "type" key.