### PR TITLE
Improve handling of failed ACME account verifications

### DIFF
--- a/src/md_acme_acct.c
+++ b/src/md_acme_acct.c
@@ -358,11 +358,16 @@ static apr_status_t acct_find_and_verify(md_store_t *store, md_store_group_t gro
 apr_status_t md_acme_find_acct_for_md(md_acme_t *acme, md_store_t *store, const md_t *md)
 {
     apr_status_t rv;
+    int max_retries = acme->max_retries;
     
     while (APR_EAGAIN == (rv = acct_find_and_verify(store, MD_SG_ACCOUNTS, 
                                                     mk_acct_pattern(acme->p, acme), 
                                                     acme, md, acme->p))) {
-        /* nop */
+        if (max_retries == 0) {
+            break;
+        }
+
+        --max_retries;
     }
     
     if (APR_STATUS_IS_ENOENT(rv)) {

--- a/src/md_store_fs.c
+++ b/src/md_store_fs.c
@@ -517,6 +517,7 @@ static apr_status_t mk_group_dir(const char **pdir, md_store_fs_t *s_fs,
 {
     const perms_t *perms;
     apr_status_t rv;
+    apr_finfo_t finfo;
     
     perms = gperms(s_fs, group);
 
@@ -531,10 +532,17 @@ static apr_status_t mk_group_dir(const char **pdir, md_store_fs_t *s_fs,
         dispatch(s_fs, MD_S_FS_EV_CREATED, group, *pdir, APR_DIR, p);
     }
 
-    rv = apr_file_perms_set(*pdir, perms->dir);
-    md_log_perror(MD_LOG_MARK, MD_LOG_TRACE3, rv, p, "mk_group_dir %s perm set", *pdir);
-    if (APR_STATUS_IS_ENOTIMPL(rv)) {
+    if (APR_SUCCESS == apr_stat(&finfo, *pdir, APR_FINFO_PROT, p)
+            && finfo.protection == perms->dir) {
+        /* the permissions are correct */
         rv = APR_SUCCESS;
+    }
+    else {
+        rv = apr_file_perms_set(*pdir, perms->dir);
+        md_log_perror(MD_LOG_MARK, MD_LOG_TRACE3, rv, p, "mk_group_dir %s perm set", *pdir);
+        if (APR_STATUS_IS_ENOTIMPL(rv)) {
+            rv = APR_SUCCESS;
+        }
     }
 cleanup:
     if (APR_SUCCESS != rv) {


### PR DESCRIPTION
When saving the updated ACME account to the disk, don't set directory permissions if they are already correct. Setting directory permissions may fail if the Apache Server is not running as root anymore.

Avoid an endless loop if an ACME account cannot be verified.

Fixes #410