### PR TITLE
 * Pebble 2.9+ reports another error when terms of service agreement …

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,6 @@
+ * Pebble 2.9+ reports another error when terms of service agreement is not set.
+   Treating all "userActionRequired" errors as permanent now.
+
 v2.6.8
 ----------------------------------------------------------------------------------------------------
  * Fix the ARI related `replaces` property in ACME order creation to only

--- a/src/md_acme.c
+++ b/src/md_acme.c
@@ -49,6 +49,7 @@ struct acme_problem_status_t {
 };
 
 static acme_problem_status_t Problems[] = {
+    { "acme:error:agreementRequired",            APR_EGENERAL, 1 },
     { "acme:error:badCSR",                       APR_EINVAL,   1 },
     { "acme:error:badNonce",                     APR_EAGAIN,   0 },
     { "acme:error:badSignatureAlgorithm",        APR_EINVAL,   1 },
@@ -61,7 +62,7 @@ static acme_problem_status_t Problems[] = {
     { "acme:error:serverInternal",               APR_EGENERAL, 0 },
     { "acme:error:unauthorized",                 APR_EACCES,   0 },
     { "acme:error:unsupportedIdentifier",        APR_BADARG,   1 },
-    { "acme:error:userActionRequired",           APR_EAGAIN,   0 },
+    { "acme:error:userActionRequired",           APR_EGENERAL, 1 },
     { "acme:error:badRevocationReason",          APR_EINVAL,   1 },
     { "acme:error:caa",                          APR_EGENERAL, 0 },
     { "acme:error:dns",                          APR_EGENERAL, 0 },


### PR DESCRIPTION
…is not set.

   Treating all "userActionRequired" errors as permanent now.