### PR TITLE
Ignore invalid job.json files

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,7 @@
+ * Fix issue #420 by ignoring job.json files that claim to have completely
+   finished a certificate renewal, but have not produced the necessary
+   result files.
+
 v2.6.9
 ----------------------------------------------------------------------------------------------------
  * Pebble 2.9+ reports another error when terms of service agreement is not set.

--- a/src/md_status.c
+++ b/src/md_status.c
@@ -97,6 +97,31 @@ leave:
     return rv;
 }
 
+static int md_job_json_seems_valid(md_json_t *json, md_store_t *store,
+                                   md_store_group_t group, const char *name,
+                                   apr_pool_t *p)
+{
+
+    if (!json) return FALSE;
+    if ((group == MD_SG_STAGING) &&
+        md_json_getb(json, MD_KEY_FINISHED, NULL) &&
+        md_json_getb(json, MD_KEY_NOTIFIED_RENEWED, NULL)) {
+        md_t *md;
+        /* A finished job in the staging area needs to have produced results */
+        if(!md_exists(store, group, name, p)) return FALSE;
+
+        if (APR_SUCCESS == md_load(store, MD_SG_DOMAINS, name, &md, p)) {
+            int i;
+            for (i = 0; i < md_cert_count(md); ++i) {
+                md_pkey_spec_t *spec = md_pkeys_spec_get(md->pks, i);
+                if(md_pubcert_load(store, group, name, spec, NULL, p) != APR_SUCCESS)
+                    return FALSE;
+            }
+        }
+    }
+    return TRUE;
+}
+
 static apr_status_t job_loadj(md_json_t **pjson, md_store_group_t group, const char *name,
                               struct md_reg_t *reg, int with_log, apr_pool_t *p)
 {
@@ -104,7 +129,13 @@ static apr_status_t job_loadj(md_json_t **pjson, md_store_group_t group, const c
 
     md_store_t *store = md_reg_store_get(reg);
     rv = md_store_load_json(store, group, name, MD_FN_JOB, pjson, p);
-    if (APR_SUCCESS == rv && !with_log) md_json_del(*pjson, MD_KEY_LOG, NULL);
+    if (APR_SUCCESS == rv) {
+        if (!md_job_json_seems_valid(*pjson, store, group, name, p)) {
+          *pjson = NULL;
+          return APR_ENOENT;
+        }
+        if(!with_log) md_json_del(*pjson, MD_KEY_LOG, NULL);
+    }
     return rv;
 }
 
@@ -384,7 +415,8 @@ apr_status_t md_job_load(md_job_t *job)
     apr_status_t rv;
     
     rv = md_store_load_json(job->store, job->group, job->mdomain, MD_FN_JOB, &jprops, job->p);
-    if (APR_SUCCESS == rv) {
+    if ((APR_SUCCESS == rv) &&
+        md_job_json_seems_valid(jprops, job->store, job->group, job->mdomain, job->p)) {
         md_job_from_json(job, jprops, job->p);
     }
     return rv;

--- a/src/md_store.c
+++ b/src/md_store.c
@@ -176,6 +176,12 @@ typedef struct {
     md_store_group_t group;
 } md_group_ctx;
 
+int md_exists(md_store_t *store, md_store_group_t group,
+              const char *name, apr_pool_t *p)
+{
+    return (md_store_load_json(store, group, name, MD_FN_MD, NULL, p) == APR_SUCCESS);
+}
+
 apr_status_t md_load(md_store_t *store, md_store_group_t group, 
                      const char *name, md_t **pmd, apr_pool_t *p)
 {

--- a/src/md_store.h
+++ b/src/md_store.h
@@ -225,7 +225,9 @@ void md_store_unlock_global(md_store_t *store, apr_pool_t *p);
 /**************************************************************************************************/
 /* Storage handling utils */
 
-apr_status_t md_load(md_store_t *store, md_store_group_t group, 
+int md_exists(md_store_t *store, md_store_group_t group,
+              const char *name, apr_pool_t *p);
+apr_status_t md_load(md_store_t *store, md_store_group_t group,
                      const char *name, md_t **pmd, apr_pool_t *p);
 apr_status_t md_save(struct md_store_t *store, apr_pool_t *p, md_store_group_t group, 
                      md_t *md, int create);

--- a/test/modules/md/test_702_auto.py
+++ b/test/modules/md/test_702_auto.py
@@ -1,3 +1,4 @@
+import json
 import os
 import re
 import time
@@ -856,3 +857,29 @@ class TestAutov2:
         assert env.await_completion(domains)
         env.check_md_complete(domains[0])
 
+    # Verify issue #420. A lying job.json in staging prevents renewal by
+    # reporting it has already been done.
+    def test_md_702_080(self, env):
+        domain = self.test_domain
+        dns_list = [domain]
+        conf = MDConf(env, admin="admin@" + domain)
+        conf.add_md(dns_list)
+        conf.add_vhost(dns_list)
+        conf.install()
+        fake_job = {
+            "name": domain,
+            "finished": True,
+            "notified": True,
+            "notified-renewed": True,
+            "errors": 0,
+        }
+        staging_dir = os.path.join(env.store_dir, 'staging', domain)
+        env.mkpath(staging_dir)
+        staging_job = os.path.join(staging_dir, 'job.json')
+        with open(staging_job, 'w') as fd:
+            fd.write(json.JSONEncoder(indent="").encode(fake_job))
+        assert env.apache_restart() == 0, f'{env.apachectl_stderr}'
+        stat = env.get_md_status(domain)
+        assert stat['renew'] is True
+        assert env.await_completion([domain])
+        assert os.path.exists(env.store_domain_file(domain, 'pubcert.pem'))


### PR DESCRIPTION
 * Fix issue #420 by ignoring job.json files that claim to have completely finished a certificate renewal, but have not produced the necessary result files.